### PR TITLE
DIABLO-102, simple, configurable background-jobs thread to run Kaltura integration, etc.

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -85,6 +85,12 @@ SALESFORCE_PASSWORD = ''
 SALESFORCE_TOKEN = ''
 SALESFORCE_USERNAME = ''
 
+SCHEDULER = {
+    'auto_start': False,
+    'interval_seconds': 60,
+    'jobs': [],
+}
+
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'
 

--- a/config/test.py
+++ b/config/test.py
@@ -25,6 +25,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import os
 
+from tests.test_jobs.mock_jobs import increment_counter, reset_counter, turn_on
+
 # Base directory for the application (one level up from this config file).
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -40,6 +42,34 @@ DATA_LOCH_RDS_URI = 'postgres://diablo:diablo@localhost:5432/pazuzu_loch_test'
 INDEX_HTML = f'{BASE_DIR}/tests/static/test-index.html'
 
 LOGGING_LOCATION = 'STDOUT'
+
+SCHEDULER = {
+    'auto_start': False,
+    'interval_seconds': 0.5,
+    'jobs': [
+        {
+            'callable': turn_on,
+            'schedule': {
+                'type': 'seconds',
+                'value': 1,
+            },
+        },
+        {
+            'callable': increment_counter,
+            'schedule': {
+                'type': 'seconds',
+                'value': 1,
+            },
+        },
+        {
+            'callable': reset_counter,
+            'schedule': {
+                'type': 'day_at',
+                'value': '04:30',
+            },
+        },
+    ],
+}
 
 SQLALCHEMY_DATABASE_URI = 'postgres://diablo:diablo@localhost:5432/pazuzu_test'
 

--- a/diablo/__init__.py
+++ b/diablo/__init__.py
@@ -26,6 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from os.path import dirname
 
 from decorator import decorator
+from diablo.jobs.scheduler import Scheduler
 from diablo.lib.util import get_args_dict
 from flask import current_app as app
 from flask_caching import Cache
@@ -38,6 +39,8 @@ __version__ = '0.1'
 cache = Cache()
 
 db = SQLAlchemy()
+
+job_scheduler = Scheduler()
 
 BASE_DIR = dirname(dirname(__file__))
 

--- a/diablo/jobs/scheduler.py
+++ b/diablo/jobs/scheduler.py
@@ -1,0 +1,84 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import threading
+import time
+
+import schedule
+
+
+class Scheduler:
+
+    def __init__(self):
+        self.cease_continuous_run = threading.Event()
+        self.continuous_thread = None
+
+    def start(self, app):
+        """Continuously run, executing pending jobs per time interval.
+
+        It is intended behavior that ScheduleThread does not run missed jobs. For example, if you register a job that
+        should run every minute and yet SCHEDULER_INTERVAL is set to one hour, then your job won't run 60 times at
+        each interval. It will run once.
+        """
+        scheduler_config = app.config['SCHEDULER']
+        interval = scheduler_config['interval_seconds']
+        jobs = scheduler_config['jobs']
+
+        if jobs:
+            for job in jobs:
+                callable_ = job['callable']
+                type_ = job['schedule']['type']
+                value = job['schedule']['value']
+
+                if type_ == 'minutes':
+                    schedule.every(value).minutes.do(callable_)
+                elif type_ == 'seconds':
+                    schedule.every(value).seconds.do(callable_)
+                elif type_ == 'day_at':
+                    schedule.every().day.at(value).do(callable_)
+                else:
+                    raise BackgroundJobError(f'Unrecognized schedule type: {type_}')
+
+            class ScheduleThread(threading.Thread):
+                @classmethod
+                def run(cls):
+                    while not self.cease_continuous_run.is_set():
+                        schedule.run_pending()
+                        time.sleep(interval)
+                    schedule.clear()
+
+            self.continuous_thread = ScheduleThread()
+            self.continuous_thread.start()
+
+        else:
+            app.logger.warn('No jobs registered. Scheduler will do nothing.')
+
+    def stop(self):
+        """Cease the scheduler thread. Stops everything."""
+        self.cease_continuous_run.set()
+
+
+class BackgroundJobError(Exception):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pprintpp==0.4.0
 psycopg2==2.8.3
 python-dateutil==2.8.1
 requests==2.22.0
+schedule==0.6.0
 simple_salesforce==0.74.2
 simplejson==3.16.0
 SQLAlchemy==1.3.13

--- a/tests/test_jobs/mock_jobs.py
+++ b/tests/test_jobs/mock_jobs.py
@@ -23,26 +23,17 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from diablo import cache, db, job_scheduler
-from diablo.configs import load_configs
-from diablo.logger import initialize_logger
-from diablo.routes import register_routes
-from flask import Flask
+COUNTER = {'value': 0}
+MOCK_STATE = {'value': False}
 
 
-def create_app():
-    """Initialize app with configs."""
-    app = Flask(__name__.split('.')[0])
-    load_configs(app)
-    initialize_logger(app)
-    cache.init_app(app)
-    cache.clear()
-    db.init_app(app)
+def turn_on():
+    MOCK_STATE['value'] = True
 
-    if app.config['SCHEDULER']['auto_start']:
-        job_scheduler.start(app)
 
-    with app.app_context():
-        register_routes(app)
+def increment_counter():
+    COUNTER['value'] += 1
 
-    return app
+
+def reset_counter():
+    COUNTER['value'] = 0

--- a/tests/test_jobs/test_scheduler.py
+++ b/tests/test_jobs/test_scheduler.py
@@ -23,26 +23,22 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from diablo import cache, db, job_scheduler
-from diablo.configs import load_configs
-from diablo.logger import initialize_logger
-from diablo.routes import register_routes
-from flask import Flask
+import time
+
+from diablo.jobs.scheduler import Scheduler
+from flask import current_app as app
+from tests.test_jobs.mock_jobs import COUNTER, MOCK_STATE
 
 
-def create_app():
-    """Initialize app with configs."""
-    app = Flask(__name__.split('.')[0])
-    load_configs(app)
-    initialize_logger(app)
-    cache.init_app(app)
-    cache.clear()
-    db.init_app(app)
+class TestScheduler:
 
-    if app.config['SCHEDULER']['auto_start']:
-        job_scheduler.start(app)
+    def test_start_mock_jobs(self):
+        scheduler = Scheduler()
+        try:
+            scheduler.start(app)
+            time.sleep(2)
 
-    with app.app_context():
-        register_routes(app)
-
-    return app
+            assert COUNTER['value'] > 0
+            assert MOCK_STATE['value'] is True
+        finally:
+            scheduler.stop()


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-102

See:
* https://schedule.readthedocs.io/en/stable/
* From FAQ of docs above: https://schedule.readthedocs.io/en/stable/faq.html#how-to-continuously-run-the-scheduler-without-blocking-the-main-thread