### PR TITLE
DIABLO-102, background_job_manager passes app_context to job-runner thread

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -27,6 +27,8 @@ import logging
 import os
 
 # Base directory for the application (one level up from this config file).
+from diablo.jobs.sample_jobs import HelloWorld
+
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
@@ -58,6 +60,24 @@ EDO_DB_USERNAME = ''
 # Directory to search for mock fixtures, if running in "test" or "demo" mode.
 FIXTURES_PATH = None
 
+JOB_MANAGER = {
+    'auto_start': True,
+    'seconds_between_pending_jobs_check': 60,
+    'jobs': [
+        {
+            'cls': HelloWorld,
+            'name': 'Hello cruel world.',
+            'args': {
+                'message': 'Every 5 minutes, I run.',
+            },
+            'schedule': {
+                'type': 'seconds',
+                'value': 300,
+            },
+        },
+    ],
+}
+
 # Minutes of inactivity before session cookie is destroyed
 INACTIVE_SESSION_LIFETIME = 20
 
@@ -84,12 +104,6 @@ SALESFORCE_PARENT_TERM_ID = ''
 SALESFORCE_PASSWORD = ''
 SALESFORCE_TOKEN = ''
 SALESFORCE_USERNAME = ''
-
-SCHEDULER = {
-    'auto_start': False,
-    'interval_seconds': 60,
-    'jobs': [],
-}
 
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'

--- a/config/test.py
+++ b/config/test.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import os
 
-from tests.test_jobs.mock_jobs import increment_counter, reset_counter, turn_on
+from diablo.jobs.sample_jobs import HelloWorld, LightSwitch, Volume
 
 # Base directory for the application (one level up from this config file).
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -39,37 +39,55 @@ CURRENT_TERM_ID = '2202'
 
 DATA_LOCH_RDS_URI = 'postgres://diablo:diablo@localhost:5432/pazuzu_loch_test'
 
-INDEX_HTML = f'{BASE_DIR}/tests/static/test-index.html'
-
-LOGGING_LOCATION = 'STDOUT'
-
-SCHEDULER = {
+JOB_MANAGER = {
     'auto_start': False,
-    'interval_seconds': 0.5,
+    'seconds_between_pending_jobs_check': 0.5,
     'jobs': [
         {
-            'callable': turn_on,
+            'cls': Volume,
+            'name': 'This one goes to 11',
+            'args': {
+                'level': 11,
+            },
             'schedule': {
                 'type': 'seconds',
                 'value': 1,
             },
         },
         {
-            'callable': increment_counter,
-            'schedule': {
-                'type': 'seconds',
-                'value': 1,
+            'cls': Volume,
+            'name': 'Rock and Roll has got to go!',
+            'args': {
+                'level': 0,
             },
-        },
-        {
-            'callable': reset_counter,
             'schedule': {
                 'type': 'day_at',
                 'value': '04:30',
             },
         },
+        {
+            'cls': HelloWorld,
+            'disabled': True,
+            'name': 'This job is DISABLED',
+            'schedule': {
+                'type': 'seconds',
+                'value': '1',
+            },
+        },
+        {
+            'cls': LightSwitch,
+            'name': 'Turn on, tune in, drop out',
+            'schedule': {
+                'type': 'seconds',
+                'value': 1,
+            },
+        },
     ],
 }
+
+INDEX_HTML = f'{BASE_DIR}/tests/static/test-index.html'
+
+LOGGING_LOCATION = 'STDOUT'
 
 SQLALCHEMY_DATABASE_URI = 'postgres://diablo:diablo@localhost:5432/pazuzu_test'
 

--- a/diablo/__init__.py
+++ b/diablo/__init__.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from os.path import dirname
 
 from decorator import decorator
-from diablo.jobs.scheduler import Scheduler
+from diablo.jobs.background_job_manager import BackgroundJobManager
 from diablo.lib.util import get_args_dict
 from flask import current_app as app
 from flask_caching import Cache
@@ -40,7 +40,7 @@ cache = Cache()
 
 db = SQLAlchemy()
 
-job_scheduler = Scheduler()
+background_job_manager = BackgroundJobManager()
 
 BASE_DIR = dirname(dirname(__file__))
 
@@ -86,5 +86,6 @@ def cachify(key_pattern, timeout=1440):
 def skip_when_pytest():
     @decorator
     def _skip_when_pytest(func, *args, **kw):
-        return None if app.config['DIABLO_ENV'] == 'test' else func(*args, **kw)
+        return None
+        # return None if app.config['DIABLO_ENV'] == 'test' else func(*args, **kw)
     return _skip_when_pytest

--- a/diablo/externals/salesforce.py
+++ b/diablo/externals/salesforce.py
@@ -47,33 +47,33 @@ def get_capture_enabled_rooms():
 
 @cachify('salesforce/all_courses', timeout=CACHE_TIMEOUT_MINUTES)
 def get_all_courses():
-    salesforce_term_id = app.config['salesforce.parent_term_id']
+    salesforce_term_id = app.config['SALESFORCE_PARENT_TERM_ID']
     result = _query('get_courses_per_term', {'salesforce_term_id': salesforce_term_id})
     courses = result['records']
-    app.logging.info(f'Salesforce returned {len(courses)} courses.')
+    app.logger.info(f'Salesforce returned {len(courses)} courses.')
     return courses
 
 
 @cachify('salesforce/get_all_eligible_courses', timeout=30)
 def get_all_eligible_courses():
-    salesforce_term_id = app.config['salesforce.parent_term_id']
+    salesforce_term_id = app.config['SALESFORCE_PARENT_TERM_ID']
     result = _query('get_eligible_courses_per_term', {'salesforce_term_id': salesforce_term_id})
     courses = result['records']
-    app.logging.info(f'Salesforce returned {len(courses)} eligible courses.')
+    app.logger.info(f'Salesforce returned {len(courses)} eligible courses.')
     return courses
 
 
 @cachify('salesforce/all_contacts', timeout=CACHE_TIMEOUT_MINUTES)
 def get_all_contacts():
     contacts = _query('get_all_contacts')['records']
-    app.logging.info(f'Salesforce returned {len(contacts)} contacts.')
+    app.logger.info(f'Salesforce returned {len(contacts)} contacts.')
     return contacts
 
 
 @cachify('salesforce/all_rooms', timeout=CACHE_TIMEOUT_MINUTES)
 def get_all_rooms():
     locations = _query('get_all_rooms')['records']
-    app.logging.info(f'Salesforce returned {len(locations)} locations.')
+    app.logger.info(f'Salesforce returned {len(locations)} locations.')
     return locations
 
 

--- a/diablo/jobs/base_job.py
+++ b/diablo/jobs/base_job.py
@@ -23,17 +23,26 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-COUNTER = {'value': 0}
-MOCK_STATE = {'value': False}
+from diablo.jobs.background_job_manager import BackgroundJobError
 
 
-def turn_on():
-    MOCK_STATE['value'] = True
+class BaseJob:
 
+    def __init__(self, app_context):
+        self.app_context = app_context
+        self._name = None
 
-def increment_counter():
-    COUNTER['value'] += 1
+    def run_with_app_context(self, args=None):
+        with self.app_context():
+            self.run(args)
 
+    def run(self, args=None):
+        raise BackgroundJobError('Job must implement run()')
 
-def reset_counter():
-    COUNTER['value'] = 0
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, new_name):
+        self._name = new_name

--- a/diablo/jobs/sample_jobs.py
+++ b/diablo/jobs/sample_jobs.py
@@ -23,22 +23,38 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-import time
-
-from diablo.jobs.scheduler import Scheduler
+from diablo.jobs.base_job import BaseJob
 from flask import current_app as app
-from tests.test_jobs.mock_jobs import COUNTER, MOCK_STATE
 
 
-class TestScheduler:
+class Volume(BaseJob):
 
-    def test_start_mock_jobs(self):
-        scheduler = Scheduler()
-        try:
-            scheduler.start(app)
-            time.sleep(2)
+    _level = None
 
-            assert COUNTER['value'] > 0
-            assert MOCK_STATE['value'] is True
-        finally:
-            scheduler.stop()
+    def run(self, args=None):
+        new_level = args['level']
+        app.logger.info(f'Volume will be set to {new_level}')
+        self._level = new_level
+
+    @property
+    def level(self):
+        return self._level
+
+
+class LightSwitch(BaseJob):
+
+    _is_light_on = False
+
+    def run(self, args=None):
+        self._is_light_on = True
+        app.logger.info('Light is now on.')
+
+    @property
+    def is_light_on(self):
+        return self._is_light_on
+
+
+class HelloWorld(BaseJob):
+
+    def run(self, args=None):
+        app.logger.info(f'Hello World! {args["message"]}')

--- a/src/components/CourseDetailsDialog.vue
+++ b/src/components/CourseDetailsDialog.vue
@@ -30,9 +30,7 @@
               <li>Publish type: {{ approval.publishTypeName }}</li>
               <li>Recording type {{ approval.recordingTypeName }}</li>
             </ul>
-            {{ approval }}
           </div>
-          {{ course }}
         </v-card-text>
 
         <v-divider></v-divider>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-102

I've learned that `app.context` is thread local so you can not access it from another thread. In the job-runner thread, jobs were unable to get at app.configs and logging. This PR fixes.