### PR TITLE
DIABLO-58, grant access to private S3 bucket (diablo-deploy-configs)

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -59,3 +59,17 @@ option_settings:
 
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
+
+Resources:
+  # Grant access to private S3 bucket
+  AWSEBAutoScalingGroup:
+    Metadata:
+      AWS::CloudFormation::Authentication:
+        S3Auth:
+          type: "s3"
+          buckets: ["diablo-deploy-configs"]
+          roleName:
+            "Fn::GetOptionSetting":
+              Namespace: "aws:autoscaling:launchconfiguration"
+              OptionName: "IamInstanceProfile"
+              DefaultValue: "$IAM_INSTANCE_PROFILE"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-58

Permission to grab diablo-config from S3 when provisioning new EB instance.