### PR TITLE
DIABLO-105, kaltura_job fix: If admin approval then schedule recordings

### DIFF
--- a/diablo/models/scheduled.py
+++ b/diablo/models/scheduled.py
@@ -26,6 +26,7 @@ from datetime import datetime
 
 from diablo import db, std_commit
 from diablo.lib.util import format_days, format_time, to_isoformat
+from diablo.models.approval import NAMES_PER_PUBLISH_TYPE, NAMES_PER_RECORDING_TYPE, publish_type, recording_type
 from diablo.models.room import Room
 from sqlalchemy import and_
 from sqlalchemy.dialects.postgresql import ARRAY
@@ -40,6 +41,8 @@ class Scheduled(db.Model):
     meeting_days = db.Column(db.String, nullable=False)
     meeting_start_time = db.Column(db.String, nullable=False)
     meeting_end_time = db.Column(db.String, nullable=False)
+    publish_type = db.Column(publish_type, nullable=False)
+    recording_type = db.Column(recording_type, nullable=False)
     room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
 
@@ -51,6 +54,8 @@ class Scheduled(db.Model):
             meeting_days,
             meeting_start_time,
             meeting_end_time,
+            publish_type_,
+            recording_type_,
             room_id,
     ):
         self.section_id = section_id
@@ -59,6 +64,8 @@ class Scheduled(db.Model):
         self.meeting_days = meeting_days
         self.meeting_start_time = meeting_start_time
         self.meeting_end_time = meeting_end_time
+        self.publish_type = publish_type_
+        self.recording_type = recording_type_
         self.room_id = room_id
 
     def __repr__(self):
@@ -69,6 +76,8 @@ class Scheduled(db.Model):
                     meeting_days={self.meeting_days},
                     meeting_start_time={self.meeting_start_time},
                     meeting_end_time={self.meeting_end_time},
+                    publish_type={self.publish_type},
+                    recording_type={self.recording_type},
                     room_id={self.room_id},
                     created_at={self.created_at}>
                 """
@@ -82,6 +91,8 @@ class Scheduled(db.Model):
             meeting_days,
             meeting_start_time,
             meeting_end_time,
+            publish_type_,
+            recording_type_,
             room_id,
     ):
         scheduled = cls(
@@ -91,6 +102,8 @@ class Scheduled(db.Model):
             meeting_days=meeting_days,
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,
+            publish_type_=publish_type_,
+            recording_type_=recording_type_,
             room_id=room_id,
         )
         db.session.add(scheduled)
@@ -118,6 +131,10 @@ class Scheduled(db.Model):
             'meetingDays': format_days(self.meeting_days),
             'meetingEndTime': format_time(self.meeting_end_time),
             'meetingStartTime': format_time(self.meeting_start_time),
+            'publishType': self.publish_type,
+            'publishTypeName': NAMES_PER_PUBLISH_TYPE[self.publish_type],
+            'recordingType': self.recording_type,
+            'recordingTypeName': NAMES_PER_RECORDING_TYPE[self.recording_type],
             'room': Room.get_room(self.room_id).to_api_json() if self.room_id else None,
             'createdAt': to_isoformat(self.created_at),
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2162,12 +2162,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
-      "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.28.0.tgz",
+      "integrity": "sha512-w0Ugcq2iatloEabQP56BRWJowliXUP5Wv6f9fKzjJmDW81hOTBxRoJ4LoEOxRpz9gcY51Libytd2ba3yLmSOfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
@@ -2182,23 +2182,23 @@
       }
     },
     "@typescript-eslint/eslint-plugin-tslint": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.27.0.tgz",
-      "integrity": "sha512-CokhcCffPm3wsQN/Q+xxIzmf0+1+y2YmV/6jKuoOjvExTJVn/kVHE5CHYmJoDWEXJNBgA0+bCOSVHIEn3nfhPw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.28.0.tgz",
+      "integrity": "sha512-a6cU6aJZa10sK6DybAtOdCV/tU1rWTTurBgYtyJb2DsG3BJwF6vYob9qOKw9n3MjV/F757LGqXz3RNmrvrimww==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
         "lodash": "^4.17.15"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
-      "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz",
+      "integrity": "sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/typescript-estree": "2.28.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -2216,21 +2216,21 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
-      "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.28.0.tgz",
+      "integrity": "sha512-RqPybRDquui9d+K86lL7iPqH6Dfp9461oyqvlXMNtap+PyqYbkY5dB7LawQjDzot99fqzvS0ZLZdfe+1Bt3Jgw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.27.0",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
+        "@typescript-eslint/typescript-estree": "2.28.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
-      "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz",
+      "integrity": "sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -6198,9 +6198,9 @@
       }
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@babel/runtime": "7.9.2",
     "@mdi/font": "^5.0.45",
     "axios": "0.19.2",
-    "core-js": "^3.6.4",
+    "core-js": "^3.6.5",
     "lodash": "4.17.15",
     "moment-timezone": "0.5.28",
     "tiptap-vuetify": "2.13.2",
@@ -23,10 +23,10 @@
     "vuex": "3.1.3"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.27.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^2.27.0",
-    "@typescript-eslint/parser": "^2.27.0",
-    "@typescript-eslint/typescript-estree": "^2.27.0",
+    "@typescript-eslint/eslint-plugin": "^2.28.0",
+    "@typescript-eslint/eslint-plugin-tslint": "^2.28.0",
+    "@typescript-eslint/parser": "^2.28.0",
+    "@typescript-eslint/typescript-estree": "^2.28.0",
     "@vue/cli": "^4.3.1",
     "@vue/cli-plugin-babel": "^4.3.1",
     "@vue/cli-plugin-eslint": "^4.3.1",

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -288,6 +288,8 @@ CREATE TABLE scheduled (
     meeting_days VARCHAR(80),
     meeting_end_time VARCHAR(80),
     meeting_start_time VARCHAR(80),
+    publish_type publish_types NOT NULL,
+    recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,
     created_at timestamp with time zone NOT NULL
 );

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,11 @@
       :timeout="snackbar.timeout"
       :top="true"
     >
-      <span id="alert-text" class="title">{{ snackbar.text }}</span>
+      <span
+        id="alert-text"
+        aria-live="polite"
+        role="alert"
+        class="title">{{ snackbar.text }}</span>
       <v-btn
         id="btn-close-alert"
         text

--- a/src/views/Approve.vue
+++ b/src/views/Approve.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!loading">
+  <div v-if="!loading" class="pa-3">
     <v-container fluid>
       <v-row class="pl-3">
         <h2 id="page-title">{{ pageTitle }}</h2>
@@ -9,7 +9,7 @@
       </v-row>
       <v-row>
         <v-col lg="3" md="3" sm="3">
-          <v-card class="mb-3 mr-3 mt-3 pa-6" outlined tile>
+          <v-card class="pa-6" outlined tile>
             <v-row id="instructors">
               <v-col md="auto">
                 <v-icon>mdi-school-outline</v-icon>
@@ -69,24 +69,41 @@
             </v-row>
           </v-card>
         </v-col>
-        <v-col lg="9" md="9" sm="9">
-          <v-card
-            class="ma-3 pa-6"
-            outlined
-            tile
-          >
-            <v-container fluid>
-              <v-row class="pb-4">
-                <div>
-                  <h4>Course Capture Sign-up</h4>
-                  <div v-if="approvedByUids.length" class="font-weight-bold pb-2 pt-2 pink--text">
+        <v-col>
+          <v-card class="pa-6" outlined>
+            <v-container>
+              <v-row v-if="scheduled">
+                <v-col>
+                  <v-card tile>
+                    <v-list-item-title class="pl-4 pt-4">
+                      <h5 class="title">Recordings scheduled</h5>
+                    </v-list-item-title>
+                    <v-list-item two-line class="pb-3">
+                      <v-list-item-content>
+                        <v-list-item-title>Scheduled on</v-list-item-title>
+                        <v-list-item-subtitle>{{ scheduled.createdAt | moment('MMM DD, YYYY') }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                      <v-list-item-content>
+                        <v-list-item-title>Recording Type</v-list-item-title>
+                        <v-list-item-subtitle>{{ scheduled.recordingTypeName }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                      <v-list-item-content>
+                        <v-list-item-title>Publish Type</v-list-item-title>
+                        <v-list-item-subtitle>{{ scheduled.publishTypeName }}</v-list-item-subtitle>
+                      </v-list-item-content>
+                    </v-list-item>
+                  </v-card>
+                </v-col>
+              </v-row>
+              <v-row no-gutters class="mb-6">
+                <v-col>
+                  <div v-if="!scheduled && approvedByUids.length" class="font-weight-bold pb-5 pink--text">
                     <span v-if="mostRecentApproval.approvedByUid === $currentUser.uid">
                       You submitted the preferences below.
                     </span>
                     <div v-if="mostRecentApproval.approvedByUid !== $currentUser.uid">
-                      The preferences below were submitted by {{ getInstructorNames(approvedByUids) }}.
+                      {{ getInstructorNames(approvedByUids) }} approved.
                     </div>
-                    <div v-if="scheduled" class="pt-2">Recordings have been scheduled in Kaltura.</div>
                   </div>
                   <div>
                     The Course Capture program is the campus service for recording and publishing classroom activity. If you
@@ -100,17 +117,17 @@
                       Course Capture Services Explained <v-icon>mdi-open-in-new</v-icon>
                     </a>.
                   </div>
-                </div>
+                </v-col>
               </v-row>
-              <v-row align="center">
-                <v-col cols="4" class="mb-5">
+              <v-row v-if="!scheduled" justify="start" align="center">
+                <v-col md="3" class="mb-6">
                   <h5>
                     <label for="select-recording-type">Recording Type</label>
                     <v-tooltip id="tooltip-recording-type" bottom>
                       <template v-slot:activator="{ on }">
                         <v-icon
                           color="primary"
-                          class="pb-1 pl-1"
+                          class="pl-1"
                           dark
                           v-on="on">
                           mdi-information-outline
@@ -122,12 +139,12 @@
                     </v-tooltip>
                   </h5>
                 </v-col>
-                <v-col cols="8">
-                  <div v-if="hasNecessaryApprovals" class="pb-5">
+                <v-col md="6">
+                  <div v-if="hasNecessaryApprovals" class="mb-5">
                     {{ mostRecentApproval.recordingTypeName }}
                   </div>
                   <div v-if="!hasNecessaryApprovals">
-                    <div v-if="recordingTypeOptions.length === 1">
+                    <div v-if="recordingTypeOptions.length === 1" class="mb-5">
                       {{ recordingTypeOptions[0].text }}
                       <input type="hidden" name="recordingType" :value="recordingTypeOptions[0].value">
                     </div>
@@ -146,15 +163,15 @@
                   </div>
                 </v-col>
               </v-row>
-              <v-row align="center">
-                <v-col cols="4" class="mb-5">
+              <v-row v-if="!scheduled" justify="start" align="center">
+                <v-col md="3" class="mb-6">
                   <h5>
                     <label for="select-publish-type">Publish</label>
                     <v-tooltip id="tooltip-publish" bottom>
                       <template v-slot:activator="{ on }">
                         <v-icon
                           color="primary"
-                          class="pb-1 pl-1"
+                          class="pl-1"
                           dark
                           v-on="on">
                           mdi-information-outline
@@ -168,8 +185,8 @@
                     </v-tooltip>
                   </h5>
                 </v-col>
-                <v-col cols="8">
-                  <div v-if="hasNecessaryApprovals" id="approved-publish-type" class="pb-5">
+                <v-col md="6">
+                  <div v-if="hasNecessaryApprovals" id="approved-publish-type" class="mb-5">
                     {{ mostRecentApproval.publishTypeName }}
                   </div>
                   <v-select
@@ -178,39 +195,42 @@
                     v-model="publishType"
                     item-text="text"
                     item-value="value"
-                    :full-width="true"
                     :items="publishTypeOptions"
                     label="Select..."
                     solo
                   ></v-select>
                 </v-col>
               </v-row>
-              <v-row v-if="!hasNecessaryApprovals">
-                <v-col md="auto" class="mr-0 pr-0">
-                  <v-checkbox id="agree-to-terms-checkbox" v-model="agreedToTerms" class="mt-0 mr-0 pt-1"></v-checkbox>
+              <v-row v-if="!hasNecessaryApprovals" no-gutters align="start">
+                <v-col md="auto">
+                  <v-checkbox id="agree-to-terms-checkbox" v-model="agreedToTerms" class="mt-0"></v-checkbox>
                 </v-col>
                 <v-col>
-                  <label for="agree-to-terms-checkbox">
-                    I have read the Audio and Video Recording Permission Agreement and I agree to the terms stated within.
-                    <a
-                      id="link-to-course-capture-policies"
-                      :href="$config.courseCapturePoliciesUrl"
-                      target="_blank"
-                      aria-label="Open URL to Course Capture policies in a new window">
-                      Audio and Video Recording Permission Agreement <v-icon>mdi-open-in-new</v-icon>
-                    </a>.
-                  </label>
+                  <div class="pt-1">
+                    <label for="agree-to-terms-checkbox">
+                      I have read the Audio and Video Recording Permission Agreement and I agree to the terms stated within.
+                      <a
+                        id="link-to-course-capture-policies"
+                        :href="$config.courseCapturePoliciesUrl"
+                        target="_blank"
+                        aria-label="Open URL to Course Capture policies in a new window">
+                        Audio and Video Recording Permission Agreement <v-icon>mdi-open-in-new</v-icon>
+                      </a>.
+                    </label>
+                  </div>
                 </v-col>
               </v-row>
-              <v-row v-if="!hasNecessaryApprovals" class="pr-5">
+              <v-row v-if="!hasNecessaryApprovals" lg="2">
                 <v-spacer />
-                <v-btn
-                  id="btn-approve"
-                  color="success"
-                  :disabled="disableSubmit"
-                  @click="approveRecording">
-                  Approve
-                </v-btn>
+                <v-col md="2">
+                  <v-btn
+                    id="btn-approve"
+                    color="success"
+                    :disabled="disableSubmit"
+                    @click="approveRecording">
+                    Approve
+                  </v-btn>
+                </v-col>
               </v-row>
             </v-container>
           </v-card>
@@ -234,7 +254,6 @@
       approvedByUids: undefined,
       course: undefined,
       hasNecessaryApprovals: undefined,
-      instructorUids: undefined,
       mostRecentApproval: undefined,
       pageTitle: undefined,
       publishType: undefined,
@@ -264,8 +283,9 @@
         }).catch(this.$ready)
       },
       getInstructorNames(uids) {
-        const instructors = this.$_.filter(this.instructors, instructor => this.$_.includes(uids, instructor.uid))
-        const unrecognized = this.$_.difference(uids, this.$_.map(this.instructors, 'uid'))
+        const instructors = this.course.instructors
+        const filtered = this.$_.filter(instructors, instructor => this.$_.includes(uids, instructor.uid))
+        const unrecognized = this.$_.difference(uids, this.$_.map(filtered, 'uid'))
         const names = this.$_.union(this.$_.map(instructors, 'name'), unrecognized)
         return names.length ? this.oxfordJoin(names) : ''
       },
@@ -290,7 +310,6 @@
           }
         }
         this.hasNecessaryApprovals = data.hasNecessaryApprovals
-        this.instructorUids = this.$_.map(data.instructors, 'uid')
         this.pageTitle = `${data.courseName } - ${data.instructionFormat} ${data.sectionNum}`
         this.publishTypeOptions = []
         this.$_.each(data.publishTypeOptions, (text, value) => {

--- a/src/views/Ouija.vue
+++ b/src/views/Ouija.vue
@@ -60,7 +60,16 @@
                 :value="item"
               ></v-checkbox>
             </td>
-            <td :id="`course-name-${item.sectionId}`" class="text-no-wrap">{{ item.courseName }}</td>
+            <td :id="`course-name-${item.sectionId}`" class="text-no-wrap">
+              <router-link
+                v-if="item.room.capability"
+                :id="`sign-up-${item.sectionId}`"
+                class="subtitle-1"
+                :to="`/approve/${$config.currentTermId}/${item.sectionId}`">
+                {{ item.courseName }}
+              </router-link>
+              <span v-if="!item.room.capability">{{ item.courseName }}</span>
+            </td>
             <td :id="`section-id-${item.sectionId}`" class="text-no-wrap w-10">{{ item.sectionId }}</td>
             <td class="text-no-wrap">
               <router-link

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -314,7 +314,7 @@ class TestCoursesFilter:
                 recording_type_='presentation_audio',
                 room_id=room.id,
             )
-            Approval.create(
+            approval = Approval.create(
                 approved_by_uid=admin_uid,
                 term_id=self.term_id,
                 section_id=section_4_id,
@@ -334,6 +334,8 @@ class TestCoursesFilter:
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
                 instructor_uids=SisSection.get_instructor_uids(term_id=self.term_id, section_id=section_2_id),
+                publish_type_=approval.publish_type,
+                recording_type_=approval.recording_type,
                 room_id=room.id,
             )
             api_json = self._api_courses(client, term_id=self.term_id, filter_='Invited')
@@ -341,7 +343,9 @@ class TestCoursesFilter:
             section_4 = next((s for s in api_json if s['sectionId'] == section_4_id), None)
             assert section_4
             assert len(section_4['approvals']) > 0
-            assert len(section_4['scheduled']) > 0
+            scheduled = section_4.get('scheduled', {})
+            assert scheduled.get('publishType') == approval.publish_type
+            assert scheduled.get('recordingType') == approval.recording_type
 
             section_5 = next((s for s in api_json if s['sectionId'] == section_5_id), None)
             assert section_5
@@ -396,6 +400,8 @@ class TestCoursesChanges:
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,
             instructor_uids=SisSection.get_instructor_uids(term_id=self.term_id, section_id=section_2_id),
+            publish_type_='kaltura_media_gallery',
+            recording_type_='presenter_presentation_audio',
             room_id=obsolete_room.id,
         )
         std_commit(allow_test_environment=True)
@@ -424,6 +430,8 @@ class TestCoursesChanges:
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,
             instructor_uids=SisSection.get_instructor_uids(term_id=self.term_id, section_id=section_1_id),
+            publish_type_='canvas',
+            recording_type_='presentation_audio',
             room_id=course['room']['id'],
         )
         std_commit(allow_test_environment=True)
@@ -450,6 +458,8 @@ class TestCoursesChanges:
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,
             instructor_uids=instructor_uids + ['999999'],
+            publish_type_='canvas',
+            recording_type_='presenter_audio',
             room_id=course['room']['id'],
         )
         std_commit(allow_test_environment=True)

--- a/tests/test_jobs/test_email_alerts_for_admins.py
+++ b/tests/test_jobs/test_email_alerts_for_admins.py
@@ -43,7 +43,7 @@ class TestEmailAlertsForAdmins:
             approved_by_uid = '6789'
             the_old_room = 'Wheeler 150'
             scheduled_in_room = Room.find_room(the_old_room)
-            Approval.create(
+            approval = Approval.create(
                 approved_by_uid=approved_by_uid,
                 term_id=term_id,
                 section_id=section_id,
@@ -63,6 +63,8 @@ class TestEmailAlertsForAdmins:
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
+                publish_type_=approval.publish_type,
+                recording_type_=approval.recording_type,
                 room_id=scheduled_in_room.id,
             )
 
@@ -78,7 +80,7 @@ class TestEmailAlertsForAdmins:
             section_id = 22287
             approved_by_uid = '8765432'
             room_id = Room.find_room('Barker 101').id
-            Approval.create(
+            approval = Approval.create(
                 approved_by_uid=approved_by_uid,
                 term_id=term_id,
                 section_id=section_id,
@@ -98,6 +100,8 @@ class TestEmailAlertsForAdmins:
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
+                publish_type_=approval.publish_type,
+                recording_type_=approval.recording_type,
                 room_id=room_id,
             )
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-105

And:
* The `scheduled` table gets two new columns: `publish_type` and `recording_type`. Those values should always match the latest approval.
* For courses with recordings scheduled, the info is nicely displayed on `/approve` page.