### PR TITLE
DIABLO-222, diablo dblink to sis_schema, not intermediate schema

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -123,7 +123,7 @@ LOGGING_LEVEL = logging.DEBUG
 LOGGING_PROPAGATION_LEVEL = logging.INFO
 
 REDSHIFT_DATABASE = 'redshift_database'
-REDSHIFT_SCHEMA_INTERMEDIATE = 'intermediate'
+REDSHIFT_SCHEMA_SIS = 'sis_data_ext_dev'
 
 REMEMBER_COOKIE_NAME = 'remember_diablo_token'
 

--- a/diablo/lib/db.py
+++ b/diablo/lib/db.py
@@ -67,7 +67,7 @@ def resolve_sql_template_string(template_string):
     return template_string.format(
         **{
             'rds_dblink_to_redshift': app.config['REDSHIFT_DATABASE'] + '_redshift',
-            'redshift_schema_intermediate': app.config['REDSHIFT_SCHEMA_INTERMEDIATE'],
+            'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
             'term_id': app.config['CURRENT_TERM_ID'],
         },
     )

--- a/diablo/sql_templates/update_rds_sis_sections.template.sql
+++ b/diablo/sql_templates/update_rds_sis_sections.template.sql
@@ -32,11 +32,12 @@ INSERT INTO sis_sections (sis_term_id, sis_section_id, is_primary, sis_course_na
       meeting_location, meeting_days, meeting_start_time, meeting_end_time, meeting_start_date, meeting_end_date)
 
    (SELECT * FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
-    SELECT sis_term_id::INTEGER, sis_section_id::INTEGER, is_primary::BOOLEAN, sis_course_name, sis_course_title,
-      sis_instruction_format, sis_section_num, allowed_units, instructor_uid, instructor_name, instructor_role_code,
+    SELECT
+      term_id::INTEGER, section_id::INTEGER, is_primary::BOOLEAN, course_display_name, course_title,
+      instruction_format, section_num, allowed_units, instructor_uid, instructor_name, instructor_role_code,
       meeting_location, meeting_days, meeting_start_time, meeting_end_time, meeting_start_date, meeting_end_date
-    FROM {redshift_schema_intermediate}.sis_sections
-    WHERE sis_term_id='{term_id}'
+    FROM {redshift_schema_sis}.courses
+    WHERE term_id='{term_id}'
   $REDSHIFT$)
   AS redshift_sis_sections (
     sis_term_id INTEGER,

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -341,6 +341,8 @@ ALTER SEQUENCE sis_sections_id_seq OWNED BY sis_sections.id;
 ALTER TABLE ONLY sis_sections ALTER COLUMN id SET DEFAULT nextval('sis_sections_id_seq'::regclass);
 ALTER TABLE ONLY sis_sections
     ADD CONSTRAINT sis_sections_pkey PRIMARY KEY (id);
+ALTER TABLE sis_sections ALTER COLUMN created_at SET DEFAULT now();
+
 CREATE INDEX sis_sections_instructor_uid_idx ON sis_sections USING btree (instructor_uid);
 CREATE INDEX sis_sections_meeting_location_idx ON sis_sections USING btree (meeting_location);
 CREATE INDEX sis_sections_term_id_section_id_idx ON sis_sections(sis_term_id, sis_section_id);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-222

I had to `ALTER COLUMN created_at SET DEFAULT now()` – I could not get `now()` to work in the sql_template query.  I might give diablo's sis_sections table a slight refactor and drop the created_at column in the process. It seems superfluous.