### PR TITLE
DIABLO-103 / DIABLO-282, store kaltura_schedule_id from API response in 'scheduled' table; delete Kaltura series when click 'Unschedule'

### DIFF
--- a/diablo/__init__.py
+++ b/diablo/__init__.py
@@ -83,8 +83,8 @@ def cachify(key_pattern, timeout=1440):
     return _cachify
 
 
-def skip_when_pytest():
+def skip_when_pytest(mock_object=None):
     @decorator
     def _skip_when_pytest(func, *args, **kw):
-        return None if app.config['DIABLO_ENV'] == 'test' else func(*args, **kw)
+        return mock_object if app.config['DIABLO_ENV'] == 'test' else func(*args, **kw)
     return _skip_when_pytest

--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -47,6 +47,10 @@ class Kaltura:
         # TODO: Close Kaltura client connection?
         pass
 
+    @skip_when_pytest()
+    def delete_scheduled_recordings(self, kaltura_schedule_id):
+        return self.kaltura_client.schedule.scheduleEvent.delete(kaltura_schedule_id)
+
     @cachify('kaltura/get_schedule_event_list', timeout=30)
     def get_schedule_event_list(self, kaltura_resource_id):
         response = self.kaltura_client.schedule.scheduleEvent.list(
@@ -63,7 +67,7 @@ class Kaltura:
         )
         return [{'id': o.id, 'name': o.name} for o in response.objects]
 
-    @skip_when_pytest()
+    @skip_when_pytest(mock_object=int(datetime.now().timestamp()))
     def schedule_recording(
             self,
             course_label,
@@ -181,7 +185,8 @@ class Kaltura:
             updatedAt=utc_now_timestamp,
         )
         # Error codes: https://developer.kaltura.com/api-docs/Error_Codes
-        return self.kaltura_client.schedule.scheduleEvent.add(recurring_event)
+        kaltura_schedule = self.kaltura_client.schedule.scheduleEvent.add(recurring_event)
+        return kaltura_schedule.id
 
     def ping(self):
         filter_ = KalturaMediaEntryFilter()

--- a/diablo/jobs/util.py
+++ b/diablo/jobs/util.py
@@ -179,8 +179,7 @@ def schedule_recordings(all_approvals, course):
                 Schedule: {days}, {adjusted_start_time} to {adjusted_end_time}
                 Recording: {approval.recording_type}; {approval.publish_type}
         """)
-        # TODO: Grab series id from the following return value and put it in db
-        Kaltura().schedule_recording(
+        kaltura_schedule_id = Kaltura().schedule_recording(
             course_label=course['label'],
             instructors=course['instructors'],
             days=days,
@@ -193,6 +192,7 @@ def schedule_recordings(all_approvals, course):
         )
         scheduled = Scheduled.create(
             instructor_uids=[i['uid'] for i in course['instructors']],
+            kaltura_schedule_id=kaltura_schedule_id,
             meeting_days=meeting_days,
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,

--- a/diablo/models/scheduled.py
+++ b/diablo/models/scheduled.py
@@ -38,6 +38,7 @@ class Scheduled(db.Model):
     section_id = db.Column(db.Integer, nullable=False, primary_key=True)
     term_id = db.Column(db.Integer, nullable=False, primary_key=True)
     instructor_uids = db.Column(ARRAY(db.String(80)), nullable=False)
+    kaltura_schedule_id = db.Column(db.Integer, nullable=False)
     meeting_days = db.Column(db.String, nullable=False)
     meeting_start_time = db.Column(db.String, nullable=False)
     meeting_end_time = db.Column(db.String, nullable=False)
@@ -51,6 +52,7 @@ class Scheduled(db.Model):
             section_id,
             term_id,
             instructor_uids,
+            kaltura_schedule_id,
             meeting_days,
             meeting_start_time,
             meeting_end_time,
@@ -61,6 +63,7 @@ class Scheduled(db.Model):
         self.section_id = section_id
         self.term_id = term_id
         self.instructor_uids = instructor_uids
+        self.kaltura_schedule_id = kaltura_schedule_id
         self.meeting_days = meeting_days
         self.meeting_start_time = meeting_start_time
         self.meeting_end_time = meeting_end_time
@@ -73,6 +76,7 @@ class Scheduled(db.Model):
                     section_id={self.section_id},
                     term_id={self.term_id},
                     instructor_uids={', '.join(self.instructor_uids)},
+                    kaltura_schedule_id={self.kaltura_schedule_id}
                     meeting_days={self.meeting_days},
                     meeting_start_time={self.meeting_start_time},
                     meeting_end_time={self.meeting_end_time},
@@ -88,6 +92,7 @@ class Scheduled(db.Model):
             section_id,
             term_id,
             instructor_uids,
+            kaltura_schedule_id,
             meeting_days,
             meeting_start_time,
             meeting_end_time,
@@ -97,6 +102,7 @@ class Scheduled(db.Model):
     ):
         scheduled = cls(
             instructor_uids=instructor_uids,
+            kaltura_schedule_id=kaltura_schedule_id,
             meeting_days=meeting_days,
             meeting_start_time=meeting_start_time,
             meeting_end_time=meeting_end_time,
@@ -127,6 +133,7 @@ class Scheduled(db.Model):
         return {
             'createdAt': to_isoformat(self.created_at),
             'instructorUids': self.instructor_uids,
+            'kalturaScheduleId': self.kaltura_schedule_id,
             'meetingDays': format_days(self.meeting_days),
             'meetingEndTime': format_time(self.meeting_end_time),
             'meetingStartTime': format_time(self.meeting_start_time),

--- a/scripts/db/migrate/2020/20200512-DIABLO-103/add_column_kaltura_schedule_id.sql
+++ b/scripts/db/migrate/2020/20200512-DIABLO-103/add_column_kaltura_schedule_id.sql
@@ -1,0 +1,31 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+DELETE FROM scheduled;
+ALTER TABLE scheduled ADD COLUMN kaltura_schedule_id INTEGER NOT NULL;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -269,6 +269,7 @@ CREATE TABLE scheduled (
     section_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
     instructor_uids VARCHAR(80)[] NOT NULL,
+    kaltura_schedule_id INTEGER NOT NULL,
     meeting_days VARCHAR(80),
     meeting_end_time VARCHAR(80),
     meeting_start_time VARCHAR(80),

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -150,6 +150,16 @@
                   <v-card tile>
                     <v-list-item-title class="pl-4 pt-4">
                       <h4 class="title">Recordings scheduled</h4>
+                      <div v-if="$currentUser.isAdmin">
+                        <a
+                          id="link-to-edit-kaltura-event"
+                          :href="`${$config.kalturaMediaSpaceUrl}/recscheduling/index/edit-event/eventid/${scheduled.kalturaScheduleId}`"
+                          target="_blank"
+                          aria-label="Open Kaltura MediaSpace in a new window"
+                        >
+                          Kaltura event {{ scheduled.kalturaScheduleId }} <v-icon small class="pb-1">mdi-open-in-new</v-icon>
+                        </a>
+                      </div>
                     </v-list-item-title>
                     <v-list-item two-line class="pb-3">
                       <v-list-item-content>

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -23,6 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 import json
+import random
 
 from diablo import std_commit
 from diablo.models.approval import Approval
@@ -603,6 +604,7 @@ class TestCoursesChanges:
 
             Scheduled.create(
                 instructor_uids=get_instructor_uids(term_id=self.term_id, section_id=section_1_id),
+                kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=obsolete_meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
@@ -631,6 +633,7 @@ class TestCoursesChanges:
             instructor_uids = get_instructor_uids(term_id=self.term_id, section_id=section_3_id)
             Scheduled.create(
                 instructor_uids=instructor_uids + ['100099'],
+                kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
@@ -872,6 +875,7 @@ def _schedule_recordings(
     )
     Scheduled.create(
         instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
+        kaltura_schedule_id=random.randint(1, 10),
         meeting_days=meeting_days,
         meeting_start_time=meeting_start_time,
         meeting_end_time=meeting_end_time,

--- a/tests/test_jobs/test_email_alerts_for_admins.py
+++ b/tests/test_jobs/test_email_alerts_for_admins.py
@@ -22,6 +22,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
+import random
+
 from diablo import std_commit
 from diablo.jobs.admin_emails_job import AdminEmailsJob
 from diablo.models.approval import Approval
@@ -60,6 +62,7 @@ class TestEmailAlertsForAdmins:
             )
             Scheduled.create(
                 instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
+                kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
@@ -97,6 +100,7 @@ class TestEmailAlertsForAdmins:
             )
             Scheduled.create(
                 instructor_uids=get_instructor_uids(section_id=section_id, term_id=term_id),
+                kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-103
https://jira.ets.berkeley.edu/jira/browse/DIABLO-282

And, if course has recordings scheduled then admin-user gets a link to Kaltura from `/course` page.