### PR TITLE
DIABLO-251, proper background_job_manager.restart when job settings change; auto_start=True for tests

### DIFF
--- a/diablo/api/job_controller.py
+++ b/diablo/api/job_controller.py
@@ -29,6 +29,7 @@ from diablo.api.util import admin_required
 from diablo.factory import background_job_manager
 from diablo.jobs.background_job_manager import BackgroundJobManager
 from diablo.lib.http import tolerant_jsonify
+from diablo.lib.util import to_isoformat
 from diablo.models.job import Job
 from diablo.models.job_history import JobHistory
 from flask import current_app as app, request
@@ -39,7 +40,7 @@ from flask import current_app as app, request
 def start_job(job_key):
     job_class = next((job for job in BackgroundJobManager.available_job_classes() if job.key() == job_key), None)
     if job_class:
-        job_class(app.app_context).run_with_app_context()
+        job_class(app.app_context).run()
         return tolerant_jsonify(_job_class_to_json(job_class))
     else:
         raise ResourceNotFoundError(f'Invalid job_key: {job_key}')
@@ -57,8 +58,7 @@ def job_disable():
     job = Job.update_disabled(job_id=job_id, disable=disable)
 
     if background_job_manager.is_running():
-        background_job_manager.stop()
-        background_job_manager.start(app)
+        background_job_manager.restart(app)
 
     return tolerant_jsonify(job.to_api_json())
 
@@ -75,9 +75,8 @@ def update_schedule():
         raise BadRequestError('Required parameters are missing.')
     job = Job.update_schedule(job_id=job_id, schedule_type=schedule_type, schedule_value=schedule_value)
 
-    if not job.disabled and background_job_manager.is_running():
-        background_job_manager.stop()
-        background_job_manager.start(app)
+    if background_job_manager.is_running():
+        background_job_manager.restart(app)
 
     return tolerant_jsonify(job.to_api_json())
 
@@ -103,6 +102,7 @@ def job_schedule():
         'autoStart': app.config['JOBS_AUTO_START'],
         'jobs': [],
         'secondsBetweenJobsCheck': app.config['JOBS_SECONDS_BETWEEN_PENDING_CHECK'],
+        'startedAt': to_isoformat(background_job_manager.get_started_at()),
     }
     for job in Job.get_all(include_disabled=True):
         job_class = next((j for j in BackgroundJobManager.available_job_classes() if j.key() == job.key), None)

--- a/diablo/factory.py
+++ b/diablo/factory.py
@@ -45,7 +45,18 @@ def create_app():
 
     with app.app_context():
         register_routes(app)
-        if app.config['JOBS_AUTO_START'] and (not app.debug or os.environ.get('WERKZEUG_RUN_MAIN') == 'true'):
-            background_job_manager.start(app)
+        _register_jobs(app)
 
     return app
+
+
+def _register_jobs(app):
+    from diablo.jobs.admin_emails_job import AdminEmailsJob  # noqa
+    from diablo.jobs.canvas_job import CanvasJob  # noqa
+    from diablo.jobs.instructor_emails_job import InstructorEmailsJob  # noqa
+    from diablo.jobs.kaltura_job import KalturaJob  # noqa
+    from diablo.jobs.queued_emails_job import QueuedEmailsJob  # noqa
+    from diablo.jobs.sis_data_refresh_job import SisDataRefreshJob  # noqa
+
+    if app.config['JOBS_AUTO_START'] and (not app.debug or os.environ.get('WERKZEUG_RUN_MAIN') == 'true'):
+        background_job_manager.start(app)

--- a/diablo/jobs/admin_emails_job.py
+++ b/diablo/jobs/admin_emails_job.py
@@ -37,7 +37,7 @@ from flask import current_app as app
 
 class AdminEmailsJob(BaseJob):
 
-    def run(self):
+    def _run(self):
         self.term_id = app.config['CURRENT_TERM_ID']
         self.all_scheduled = Scheduled.get_all_scheduled(term_id=self.term_id)
         if self.all_scheduled:

--- a/diablo/jobs/canvas_job.py
+++ b/diablo/jobs/canvas_job.py
@@ -30,7 +30,7 @@ from flask import current_app as app
 
 class CanvasJob(BaseJob):
 
-    def run(self, args=None):
+    def _run(self):
         CanvasCourseSite.refresh_term_data(
             term_id=app.config['CURRENT_TERM_ID'],
             canvas_course_sites=get_canvas_course_sites(),

--- a/diablo/jobs/doomed_to_failure.py
+++ b/diablo/jobs/doomed_to_failure.py
@@ -27,7 +27,7 @@ from diablo.jobs.base_job import BaseJob
 
 class DoomedToFailure(BaseJob):
 
-    def run(self):
+    def _run(self):
         secret_of_life = 1 / 0
         return secret_of_life
 

--- a/diablo/jobs/instructor_emails_job.py
+++ b/diablo/jobs/instructor_emails_job.py
@@ -36,7 +36,7 @@ from flask import current_app as app
 
 class InstructorEmailsJob(BaseJob):
 
-    def run(self):
+    def _run(self):
         self.term_id = app.config['CURRENT_TERM_ID']
         self.email_new_invites()
         self.email_scheduled_courses()

--- a/diablo/jobs/kaltura_job.py
+++ b/diablo/jobs/kaltura_job.py
@@ -36,7 +36,7 @@ from flask import current_app as app
 
 class KalturaJob(BaseJob):
 
-    def run(self, args=None):
+    def _run(self):
         term_id = app.config['CURRENT_TERM_ID']
         approvals = Approval.get_approvals_per_term(term_id=term_id)
         if approvals:

--- a/diablo/jobs/queued_emails_job.py
+++ b/diablo/jobs/queued_emails_job.py
@@ -31,7 +31,7 @@ from flask import current_app as app
 
 class QueuedEmailsJob(BaseJob):
 
-    def run(self, args=None):
+    def _run(self, args=None):
         term_id = app.config['CURRENT_TERM_ID']
         for queued_email in QueuedEmail.get_all(term_id):
             course = SisSection.get_course(term_id, queued_email.section_id)

--- a/diablo/jobs/sis_data_refresh_job.py
+++ b/diablo/jobs/sis_data_refresh_job.py
@@ -33,7 +33,7 @@ from flask import current_app as app
 
 class SisDataRefreshJob(BaseJob):
 
-    def run(self, args=None):
+    def _run(self, args=None):
         resolved_ddl_rds = resolve_sql_template('update_rds_sis_sections.template.sql')
         if execute(resolved_ddl_rds):
             term_id = app.config['CURRENT_TERM_ID']

--- a/diablo/models/development_db.py
+++ b/diablo/models/development_db.py
@@ -26,12 +26,8 @@ import glob
 import json
 
 from diablo import BASE_DIR, cache, db, std_commit
-from diablo.jobs.admin_emails_job import AdminEmailsJob  # noqa
+from diablo.factory import background_job_manager
 from diablo.jobs.canvas_job import CanvasJob
-from diablo.jobs.doomed_to_failure import DoomedToFailure  # noqa
-from diablo.jobs.instructor_emails_job import InstructorEmailsJob  # noqa
-from diablo.jobs.kaltura_job import KalturaJob  # noqa
-from diablo.jobs.queued_emails_job import QueuedEmailsJob  # noqa
 from diablo.jobs.sis_data_refresh_job import SisDataRefreshJob
 from diablo.lib.util import utc_now
 from diablo.models.admin_user import AdminUser
@@ -42,7 +38,7 @@ from diablo.models.sent_email import SentEmail
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
 from sqlalchemy.sql import text
-
+from tests.util import simply_yield
 
 _test_users = [
     {
@@ -164,13 +160,15 @@ def _create_users():
 
 
 def _set_up_and_run_jobs():
+    Job.create(job_schedule_type='day_at', job_schedule_value='15:00', key='kaltura')
     Job.create(job_schedule_type='day_at', job_schedule_value='04:30', key='queued_emails')
-    Job.create(job_schedule_type='seconds', job_schedule_value='1', key='instructor_emails')
-    Job.create(disabled=True, job_schedule_type='seconds', job_schedule_value='1', key='admin_emails')
-    Job.create(job_schedule_type='seconds', job_schedule_value='1', key='canvas')
+    Job.create(job_schedule_type='minutes', job_schedule_value='120', key='instructor_emails')
+    Job.create(job_schedule_type='minutes', job_schedule_value='120', key='admin_emails')
+    Job.create(job_schedule_type='day_at', job_schedule_value='16:00', key='canvas')
     Job.create(disabled=True, job_schedule_type='minutes', job_schedule_value='5', key='doomed_to_fail')
 
-    CanvasJob(app_context=app.app_context).run_with_app_context()
+    background_job_manager.start(app)
+    CanvasJob(app_context=simply_yield).run()
     std_commit(allow_test_environment=True)
 
 

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -26,6 +26,7 @@ import json
 import random
 
 from diablo import std_commit
+from diablo.jobs.canvas_job import CanvasJob
 from diablo.jobs.queued_emails_job import QueuedEmailsJob
 from diablo.models.approval import Approval
 from diablo.models.course_preference import CoursePreference
@@ -36,7 +37,7 @@ from diablo.models.sis_section import SisSection
 from flask import current_app as app
 import pytest
 from tests.test_api.api_test_utils import api_approve, api_get_course, get_instructor_uids
-from tests.util import test_approvals_workflow
+from tests.util import simply_yield, test_approvals_workflow
 
 admin_uid = '90001'
 deleted_admin_user_uid = '910001'
@@ -299,6 +300,7 @@ class TestGetCourse:
 
     def test_section_with_canvas_course_sites(self, client, admin_session):
         """Canvas course site information is included in the API."""
+        CanvasJob(simply_yield).run()
         api_json = api_get_course(
             client,
             term_id=self.term_id,

--- a/tests/test_jobs/test_canvas_job.py
+++ b/tests/test_jobs/test_canvas_job.py
@@ -24,16 +24,16 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 from diablo import std_commit
 from diablo.jobs.canvas_job import CanvasJob
-from flask import current_app as app
+from tests.util import simply_yield
 
 
 class TestCanvasJob:
 
     def test_refresh_term_data(self):
         """Refreshes term data without duplicate key violation in db."""
-        CanvasJob(app.app_context).run()
+        CanvasJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
-        CanvasJob(app.app_context).run()
+        CanvasJob(simply_yield).run()
         std_commit(allow_test_environment=True)
         # If we reach this point then no error occurred.

--- a/tests/test_jobs/test_instructor_emails_job.py
+++ b/tests/test_jobs/test_instructor_emails_job.py
@@ -30,7 +30,7 @@ from diablo.models.course_preference import CoursePreference
 from diablo.models.sent_email import SentEmail
 from diablo.models.sis_section import SisSection
 from sqlalchemy.orm.session import make_transient
-from tests.util import test_approvals_workflow
+from tests.util import simply_yield, test_approvals_workflow
 
 
 class TestInstructorEmailsJob:
@@ -42,10 +42,10 @@ class TestInstructorEmailsJob:
             # The job creates many new invitations.
             timestamp = utc_now()
             # Emails are queued but not sent.
-            InstructorEmailsJob(app.app_context).run()
+            InstructorEmailsJob(simply_yield).run()
             assert len(_get_invitations_since(term_id, timestamp)) == 0
             # Emails are sent.
-            QueuedEmailsJob(app.app_context).run()
+            QueuedEmailsJob(simply_yield).run()
             invitations = _get_invitations_since(term_id, timestamp)
             assert len(invitations) == 8
 
@@ -74,8 +74,8 @@ class TestInstructorEmailsJob:
 
             # Re-run the job. An email is sent to the new instructor only.
             timestamp = utc_now()
-            InstructorEmailsJob(app.app_context).run()
-            QueuedEmailsJob(app.app_context).run()
+            InstructorEmailsJob(simply_yield).run()
+            QueuedEmailsJob(simply_yield).run()
             invitations = _get_invitations_since(term_id, timestamp)
             assert len(invitations) == 1
             invitation = invitations[0].to_api_json()
@@ -92,10 +92,10 @@ class TestInstructorEmailsJob:
 
             timestamp = utc_now()
             # Emails are queued but not sent.
-            InstructorEmailsJob(app.app_context).run()
+            InstructorEmailsJob(simply_yield).run()
             assert len(_get_invitations_since(term_id, timestamp)) == 0
             # Emails are sent.
-            QueuedEmailsJob(app.app_context).run()
+            QueuedEmailsJob(simply_yield).run()
             invitations = _get_invitations_since(term_id, timestamp)
             assert len(invitations) == 8
             assert not next((e for e in invitations if e.section_id == section_id), None)

--- a/tests/test_jobs/test_kaltura_job.py
+++ b/tests/test_jobs/test_kaltura_job.py
@@ -31,7 +31,7 @@ from diablo.models.scheduled import Scheduled
 from diablo.models.sent_email import SentEmail
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
-from tests.util import test_approvals_workflow
+from tests.util import simply_yield, test_approvals_workflow
 
 admin_uid = '90001'
 
@@ -53,7 +53,7 @@ class TestKalturaJob:
                 )
 
             emails_sent = _get_emails_sent()
-            KalturaJob(app.app_context).run()
+            KalturaJob(simply_yield).run()
             std_commit(allow_test_environment=True)
             # Expect no emails sent during action above
             assert _get_emails_sent() == emails_sent
@@ -82,7 +82,7 @@ class TestKalturaJob:
             ]
             """If we have insufficient approvals then do nothing."""
             email_count = _get_emails_sent()
-            KalturaJob(app.app_context).run()
+            KalturaJob(simply_yield).run()
             std_commit(allow_test_environment=True)
             assert _get_emails_sent() == email_count
 
@@ -100,7 +100,7 @@ class TestKalturaJob:
 
             """If a course is scheduled for recording then email is sent to its instructor(s)."""
             email_count = len(_get_emails_sent())
-            KalturaJob(app.app_context).run()
+            KalturaJob(simply_yield).run()
             std_commit(allow_test_environment=True)
 
             # Verify publish and recording types
@@ -122,7 +122,7 @@ class TestKalturaJob:
 
             """If recordings were already scheduled then do nothing, send no email."""
             email_count = len(_get_emails_sent())
-            KalturaJob(app.app_context).run()
+            KalturaJob(simply_yield).run()
             assert len(_get_emails_sent()) == email_count
 
     def test_admin_approval(self):
@@ -146,7 +146,7 @@ class TestKalturaJob:
                 section_id=section_id,
                 term_id=term_id,
             )
-            KalturaJob(app.app_context).run()
+            KalturaJob(simply_yield).run()
             std_commit(allow_test_environment=True)
             # Admin approval is all we need.
             assert Scheduled.get_scheduled(section_id=section_id, term_id=term_id)

--- a/tests/test_jobs/test_queued_emails_job.py
+++ b/tests/test_jobs/test_queued_emails_job.py
@@ -30,6 +30,7 @@ from diablo.models.queued_email import QueuedEmail
 from diablo.models.sent_email import SentEmail
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
+from tests.util import simply_yield
 
 
 class TestQueuedEmailsJob:
@@ -37,12 +38,12 @@ class TestQueuedEmailsJob:
     def test_no_email_queued(self):
         """Do nothing if 'queued_emails' table is empty."""
         term_id = app.config['CURRENT_TERM_ID']
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
         # Verify that the next job run will have zero queued emails.
         assert len(QueuedEmail.get_all(term_id=term_id)) == 0
 
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
         # If we reach this point then no error occurred.
 
@@ -71,7 +72,7 @@ class TestQueuedEmailsJob:
         before = utc_now()
         emails_sent_before = _get_emails_to_courses()
         # Run the job
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
         # Expect one email per instructor
@@ -108,7 +109,7 @@ class TestQueuedEmailsJob:
         before = utc_now()
         emails_sent_before = _emails_sent()
         # Run the job
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
         # Expect no emails sent
@@ -131,7 +132,7 @@ class TestQueuedEmailsJob:
         before = utc_now()
         emails_sent_before = _emails_sent()
         # Run the job
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
         # Expect email to admin email address
@@ -163,7 +164,7 @@ class TestQueuedEmailsJob:
 
         emails_sent_before = _emails_sent()
         # Run the job
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
         # Expect no email sent
@@ -188,7 +189,7 @@ class TestQueuedEmailsJob:
 
         emails_sent_before = _emails_sent()
         # Run the job
-        QueuedEmailsJob(app.app_context).run()
+        QueuedEmailsJob(simply_yield).run()
         std_commit(allow_test_environment=True)
 
         # Expect no email sent

--- a/tests/util.py
+++ b/tests/util.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from contextlib import contextmanager
 
 from diablo import db
+from diablo.jobs.doomed_to_failure import DoomedToFailure  # noqa
 from sqlalchemy import text
 
 
@@ -37,6 +38,11 @@ def override_config(app, key, value):
         yield
     finally:
         app.config[key] = old_value
+
+
+@contextmanager
+def simply_yield():
+    yield
 
 
 @contextmanager


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-251

Singleton in `background_job_manager` instead of hard-to-read `threading.Event` for managing restarts.