### PR TITLE
DIABLO-333 Many threads, only one daemon process

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -61,7 +61,7 @@ files:
           Require all granted
         </Directory>
 
-        WSGIDaemonProcess wsgi-ssl processes=10 threads=100 display-name=%{GROUP} \
+        WSGIDaemonProcess wsgi-ssl processes=1 threads=15 display-name=%{GROUP} \
           home=/opt/python/current/app \
           user=wsgi \
           group=wsgi


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-333

Change Diablo's Apache conf to be consistent with Nessie (and with Diablo's own AMI config).

The theory: in a classic example of managerial overreach, having ten WSGI processes is initializing ten separate BackgroundJobManagers, leaving them all to fight over an inadequate pool of labor.