### PR TITLE
DIABLO-317, alter publish_type enum; /course page text; map schedule to canvas if proper publish_type

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -38,6 +38,7 @@ CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 
 COURSE_CAPTURE_EXPLAINED_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture'
 COURSE_CAPTURE_POLICIES_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture/course-capture-instructors-getting-started/policies'
+COURSE_CAPTURE_PREMIUM_COST = 2000
 
 CACHE_DEFAULT_TIMEOUT = 86400
 CACHE_DIR = f'{BASE_DIR}/.flask_cache'

--- a/diablo/api/config_controller.py
+++ b/diablo/api/config_controller.py
@@ -42,6 +42,7 @@ def app_config():
         'canvasBaseUrl': app.config['CANVAS_BASE_URL'],
         'courseCaptureExplainedUrl': app.config['COURSE_CAPTURE_EXPLAINED_URL'],
         'courseCapturePoliciesUrl': app.config['COURSE_CAPTURE_POLICIES_URL'],
+        'courseCapturePremiumCost': app.config['COURSE_CAPTURE_PREMIUM_COST'],
         'currentTermId': term_id,
         'currentTermName': term_name_for_sis_id(term_id),
         'devAuthEnabled': app.config['DEVELOPER_AUTH_ENABLED'],

--- a/diablo/api/room_controller.py
+++ b/diablo/api/room_controller.py
@@ -38,6 +38,12 @@ def get_all_rooms():
     return tolerant_jsonify([room.to_api_json() for room in Room.all_rooms()])
 
 
+@app.route('/api/rooms/auditoriums')
+@admin_required
+def get_auditoriums():
+    return tolerant_jsonify([room.to_api_json() for room in Room.auditoriums()])
+
+
 @app.route('/api/rooms/kaltura_resources')
 @admin_required
 def kaltura_resource_list():

--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -159,10 +159,16 @@ class Kaltura:
             term_id,
     ):
         category_ids = []
-        for canvas_course_site_id in canvas_course_site_ids:
-            category = self.get_canvas_category_object(canvas_course_site_id=canvas_course_site_id)
-            if category:
-                category_ids.append(category['id'])
+
+        if publish_type == 'kaltura_media_gallery':
+            for canvas_course_site_id in canvas_course_site_ids:
+                category = self.get_canvas_category_object(canvas_course_site_id=canvas_course_site_id)
+                if category:
+                    category_ids.append(category['id'])
+        elif publish_type == 'kaltura_my_media':
+            # TODO: Category entry per instructor?!
+            pass
+
         kaltura_schedule = self._schedule_recurring_events_in_kaltura(
             category_ids=category_ids,
             course_label=course_label,
@@ -270,7 +276,6 @@ class Kaltura:
             time_minutes=end_time.minute,
         )
         media_entry = self._create_media_template(
-            category_ids=category_ids,
             description=f'Media_entry: {description}',
             name=f'Media_entry: {summary} recordings scheduled by Diablo on {to_isoformat(datetime.now())}',
         )
@@ -324,7 +329,7 @@ class Kaltura:
         )
         return self.kaltura_client.schedule.scheduleEvent.add(recurring_event)
 
-    def _create_media_template(self, category_ids, description, name):
+    def _create_media_template(self, description, name):
         media_entry = KalturaMediaEntry(
             accessControlId=3034871,  # TODO: Can we create a single access-control for all media entries?
             capabilities=NotImplemented,

--- a/diablo/models/approval.py
+++ b/diablo/models/approval.py
@@ -34,8 +34,8 @@ from sqlalchemy.dialects.postgresql import ENUM
 
 
 publish_type = ENUM(
-    'canvas',
     'kaltura_media_gallery',
+    'kaltura_my_media',
     name='publish_types',
     create_type=False,
 )
@@ -56,8 +56,8 @@ approver_type = ENUM(
 )
 
 NAMES_PER_PUBLISH_TYPE = {
-    'canvas': 'bCourses',
-    'kaltura_media_gallery': 'My Media (Kaltura)',
+    'kaltura_media_gallery': 'Media Gallery',
+    'kaltura_my_media': 'My Media',
 }
 
 NAMES_PER_RECORDING_TYPE = {

--- a/diablo/models/room.py
+++ b/diablo/models/room.py
@@ -104,6 +104,10 @@ class Room(db.Model):
         return cls.query.order_by(cls.capability, cls.location).all()
 
     @classmethod
+    def auditoriums(cls):
+        return cls.query.filter_by(is_auditorium=True).order_by(cls.capability, cls.location).all()
+
+    @classmethod
     def total_room_count(cls):
         return db.session.query(func.count(cls.id)).scalar()
 

--- a/scripts/db/migrate/2020/20200526-DIABLO-317/alter_publish_types_enum.sql
+++ b/scripts/db/migrate/2020/20200526-DIABLO-317/alter_publish_types_enum.sql
@@ -1,0 +1,44 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+DELETE FROM scheduled;
+DELETE FROM approvals;
+
+-- Rename existing TYPE
+ALTER TYPE publish_types RENAME TO publish_types_OLD;
+
+-- Create new TYPE
+CREATE TYPE publish_types AS ENUM ('kaltura_media_gallery', 'kaltura_my_media');
+
+-- Update tables to use the new TYPE
+ALTER TABLE approvals ALTER COLUMN publish_type TYPE publish_types USING publish_type::text::publish_types;
+ALTER TABLE scheduled ALTER COLUMN publish_type TYPE publish_types USING publish_type::text::publish_types;
+
+-- Remove old TYPE
+DROP TYPE publish_types_OLD;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -66,8 +66,8 @@ CREATE TYPE job_schedule_types AS ENUM (
 --
 
 CREATE TYPE publish_types AS ENUM (
-    'canvas',
-    'kaltura_media_gallery'
+    'kaltura_media_gallery',
+    'kaltura_my_media'
 );
 
 --

--- a/src/api/room.ts
+++ b/src/api/room.ts
@@ -5,6 +5,10 @@ export function getAllRooms() {
   return axios.get(`${utils.apiBaseUrl()}/api/rooms/all`)
 }
 
+export function getAuditoriums() {
+  return axios.get(`${utils.apiBaseUrl()}/api/rooms/auditoriums`)
+}
+
 export function getKalturaEventList(roomId) {
   return axios.get(`${utils.apiBaseUrl()}/api/room/${roomId}/kaltura_event_list`)
 }

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -256,7 +256,9 @@
                         </v-icon>
                       </template>
                       <div>
-                        Foo
+                        'Presentation and Audio' recordings are free.
+                        There will be a ${{ $config.courseCapturePremiumCost }} operator fee, per semester, for
+                        'Presenter' recordings in ${oxfordJoin(auditoriumNames)}.
                       </div>
                     </v-tooltip>
                   </h4>
@@ -303,9 +305,8 @@
                         </v-icon>
                       </template>
                       <div>
-                        You can publish into bCourses, under Media Gallery [link to KB article: Media Gallery] Publish
-                        under all instructors' My Media. Instructor will need to publish to Media Gallery on their own
-                        (link to KB article: publishing from my media)
+                        Choosing 'Media Gallery' will auto-publish recordings to students in bCourses.
+                        Choosing 'My Media' will allow instructors to review/edit prior to publishing to students.
                       </div>
                     </v-tooltip>
                   </h4>
@@ -381,6 +382,7 @@
   import Utils from '@/mixins/Utils'
   import {approve, getCourse, unschedule} from '@/api/course'
   import {queueEmail} from '@/api/email'
+  import {getAuditoriums} from '@/api/room'
 
   export default {
     name: 'Course',
@@ -388,6 +390,7 @@
     mixins: [Context, Utils],
     data: () => ({
       agreedToTerms: false,
+      auditoriumNames: undefined,
       course: undefined,
       kalturaScheduleDialogJSON: false,
       publishType: undefined,
@@ -414,6 +417,9 @@
         this.publishTypeOptions = []
         this.$_.each(this.$config.publishTypeOptions, (text, value) => {
           this.publishTypeOptions.push({text, value})
+        })
+        getAuditoriums().then(data => {
+          this.auditoriumNames = this.$_.map(data, 'name')
         })
       }).catch(this.$ready)
     },

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -69,7 +69,7 @@ class TestApprove:
         """Deny anonymous access."""
         api_approve(
             client,
-            publish_type='canvas',
+            publish_type='kaltura_my_media',
             recording_type='presentation_audio',
             section_id=section_1_id,
             expected_status_code=401,
@@ -90,7 +90,7 @@ class TestApprove:
         fake_auth.login('10006')
         api_approve(
             client,
-            publish_type='canvas',
+            publish_type='kaltura_my_media',
             recording_type='presentation_audio',
             section_id=section_2_id,
             expected_status_code=403,
@@ -105,7 +105,7 @@ class TestApprove:
             for expected_status_code in [200, 403]:
                 api_approve(
                     client,
-                    publish_type='canvas',
+                    publish_type='kaltura_my_media',
                     recording_type='presentation_audio',
                     section_id=section_1_id,
                     expected_status_code=expected_status_code,
@@ -118,7 +118,7 @@ class TestApprove:
             fake_auth.login(instructor_uids[0])
             api_approve(
                 client,
-                publish_type='canvas',
+                publish_type='kaltura_my_media',
                 recording_type='presentation_audio',
                 section_id=section_1_id,
             )
@@ -156,7 +156,7 @@ class TestApprove:
             assert len(approvals_) == 2
 
             assert approvals_[0]['approvedBy']['uid'] == instructor_uids[0]
-            assert approvals_[0]['publishType'] == 'canvas'
+            assert approvals_[0]['publishType'] == 'kaltura_my_media'
 
             assert approvals_[1]['approvedBy']['uid'] == instructor_uids[1]
             assert approvals_[1]['publishType'] == 'kaltura_media_gallery'
@@ -171,7 +171,7 @@ class TestApprove:
         with test_approvals_workflow(app):
             api_json = api_approve(
                 client,
-                publish_type='canvas',
+                publish_type='kaltura_my_media',
                 recording_type='presentation_audio',
                 section_id=section_1_id,
             )
@@ -186,7 +186,7 @@ class TestApprove:
                 fake_auth.login(instructor_uid)
                 api_json = api_approve(
                     client,
-                    publish_type='canvas',
+                    publish_type='kaltura_my_media',
                     recording_type='presentation_audio',
                     section_id=50012,
                 )
@@ -254,7 +254,7 @@ class TestGetCourse:
             Approval.create(
                 approved_by_uid=approved_by_uid,
                 approver_type_='instructor',
-                publish_type_='canvas',
+                publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
                 room_id=room_id,
                 section_id=section_1_id,
@@ -391,7 +391,7 @@ class TestCoursesFilter:
         Approval.create(
             approved_by_uid=get_instructor_uids(section_id=section_id, term_id=self.term_id)[0],
             approver_type_='instructor',
-            publish_type_='canvas',
+            publish_type_='kaltura_my_media',
             recording_type_='presentation_audio',
             room_id=Room.get_room_id(section_id=section_id, term_id=self.term_id),
             section_id=section_id,
@@ -619,7 +619,7 @@ class TestCoursesChanges:
                 meeting_days=obsolete_meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
-                publish_type_='canvas',
+                publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
                 room_id=Room.get_room_id(section_id=section_1_id, term_id=self.term_id),
                 section_id=section_1_id,
@@ -648,7 +648,7 @@ class TestCoursesChanges:
                 meeting_days=meeting_days,
                 meeting_start_time=meeting_start_time,
                 meeting_end_time=meeting_end_time,
-                publish_type_='canvas',
+                publish_type_='kaltura_my_media',
                 recording_type_='presenter_audio',
                 room_id=Room.get_room_id(section_id=section_3_id, term_id=self.term_id),
                 section_id=section_3_id,
@@ -842,7 +842,7 @@ class TestUnscheduleCourse:
         with test_approvals_workflow(app):
             api_approve(
                 client,
-                publish_type='canvas',
+                publish_type='kaltura_my_media',
                 recording_type='presentation_audio',
                 section_id=section_1_id,
             )

--- a/tests/test_api/test_room_controller.py
+++ b/tests/test_api/test_room_controller.py
@@ -64,6 +64,30 @@ class TestGetAllRooms:
             assert key in rooms[0]
 
 
+class TestGetAuditoriums:
+    """Only Admins can get list of auditoriums."""
+
+    @staticmethod
+    def _api_auditoriums(client, expected_status_code=200):
+        response = client.get('/api/rooms/auditoriums')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_anonymous(self, client):
+        """Denies anonymous access."""
+        self._api_auditoriums(client, expected_status_code=401)
+
+    def test_unauthorized(self, client, instructor_session):
+        """Denies access if user is not an admin."""
+        self._api_auditoriums(client, expected_status_code=401)
+
+    def test_authorized(self, client, admin_session):
+        """Admin user has access."""
+        rooms = self._api_auditoriums(client)
+        assert len(rooms) == 1
+        assert rooms[0]['location'] == 'Li Ka Shing 145'
+
+
 class TestGetRoom:
     """Only Admin users can get room info."""
 

--- a/tests/test_jobs/test_email_alerts_for_admins.py
+++ b/tests/test_jobs/test_email_alerts_for_admins.py
@@ -95,7 +95,7 @@ class TestEmailAlertsForAdmins:
             approval = Approval.create(
                 approved_by_uid=approved_by_uid,
                 approver_type_='instructor',
-                publish_type_='canvas',
+                publish_type_='kaltura_my_media',
                 recording_type_='presenter_audio',
                 room_id=room_id,
                 section_id=section_id,

--- a/tests/test_jobs/test_kaltura_job.py
+++ b/tests/test_jobs/test_kaltura_job.py
@@ -73,7 +73,7 @@ class TestKalturaJob:
                 Approval.create(
                     approved_by_uid=instructors[0]['uid'],
                     approver_type_='instructor',
-                    publish_type_='canvas',
+                    publish_type_='kaltura_my_media',
                     recording_type_='presentation_audio',
                     room_id=room_id,
                     section_id=section_id,
@@ -140,7 +140,7 @@ class TestKalturaJob:
             Approval.create(
                 approved_by_uid=admin_uid,
                 approver_type_='admin',
-                publish_type_='canvas',
+                publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
                 room_id=Room.find_room('Barker 101').id,
                 section_id=section_id,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-317

Updating enum is a must because it was wrongly organized:  'canvas' and 'kaltura_media_gallery' are not separate and distinct options – they are synonymous.