### PR TITLE
DIABLO-380, /api/start_course_capture_pilot loads pilot courses JSON (pulled from S3, like config)

### DIFF
--- a/.ebextensions/03_download_local_configuration.config
+++ b/.ebextensions/03_download_local_configuration.config
@@ -2,7 +2,8 @@
 container_commands:
   01_get_configuration_file:
     command: |
+      PYTHONPATH='' aws s3 cp s3://diablo-deploy-configs/diablo/course_capture_pilot.json config/course_capture_pilot.json
       PYTHONPATH='' aws s3 cp s3://diablo-deploy-configs/diablo/${EB_ENVIRONMENT}.py config/production-local.py
       printf "\nEB_ENVIRONMENT = '${EB_ENVIRONMENT}'\n\n" >> config/production-local.py
-      chown wsgi config/production-local.py
-      chmod 400 config/production-local.py
+      chown wsgi config/production-local.py config/course_capture_pilot.json
+      chmod 400 config/production-local.py config/course_capture_pilot.json

--- a/config/default.py
+++ b/config/default.py
@@ -34,12 +34,6 @@ BCOP_SMTP_PORT = 587
 BCOP_SMTP_SERVER = 'bcop.berkeley.edu'
 BCOP_SMTP_USERNAME = None
 
-CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
-
-COURSE_CAPTURE_EXPLAINED_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture'
-COURSE_CAPTURE_POLICIES_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture/course-capture-instructors-getting-started/policies'
-COURSE_CAPTURE_PREMIUM_COST = 2000
-
 CACHE_DEFAULT_TIMEOUT = 86400
 CACHE_DIR = f'{BASE_DIR}/.flask_cache'
 CACHE_THRESHOLD = 300
@@ -52,10 +46,17 @@ CANVAS_BERKELEY_ACCOUNT_ID = 00000
 CANVAS_BERKELEY_SUB_ACCOUNTS = [00000]
 CANVAS_ENROLLMENT_TERM_ID = 0000
 
-CURRENT_TERM_ID = None
+CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
+
+COURSE_CAPTURE_EXPLAINED_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture'
+COURSE_CAPTURE_POLICIES_URL = 'https://www.ets.berkeley.edu/services-facilities/course-capture/course-capture-instructors-getting-started/policies'
+COURSE_CAPTURE_PILOT_JSON = f'{BASE_DIR}/config/course_capture_pilot.json'
+COURSE_CAPTURE_PREMIUM_COST = 2000
+
 # YYYY-MM-DD is expected date format. For example, '2020-01-21'
 CURRENT_TERM_BEGIN = None
 CURRENT_TERM_END = None
+CURRENT_TERM_ID = None
 
 DEVELOPER_AUTH_ENABLED = False
 DEVELOPER_AUTH_PASSWORD = 'another secret'

--- a/config/test.py
+++ b/config/test.py
@@ -30,6 +30,8 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 ALERT_INFREQUENT_ACTIVITY_ENABLED = False
 ALERT_WITHDRAWAL_ENABLED = False
 
+COURSE_CAPTURE_PILOT_JSON = f'{BASE_DIR}/fixtures/sis/course_capture_pilot.json'
+
 CURRENT_TERM_ID = 2202
 CURRENT_TERM_BEGIN = '2020-01-21'
 CURRENT_TERM_END = '2020-05-08'

--- a/diablo/lib/development_db_utils.py
+++ b/diablo/lib/development_db_utils.py
@@ -1,0 +1,98 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+import json
+
+from diablo import db, std_commit
+from diablo.api.errors import InternalServerError
+from diablo.lib.util import utc_now
+from diablo.models.sis_section import SisSection
+from flask import current_app as app
+
+
+def load_mock_courses(json_file_path):
+    courses = _load_mock_courses(json_file_path)
+    if SisSection.get_course(term_id=courses[0]['term_id'], section_id=courses[0]['section_id']):
+        raise InternalServerError(f'The course data in {json_file_path} has already been loaded')
+    else:
+        _save_courses(sis_sections=courses)
+        std_commit(allow_test_environment=True)
+
+
+def _load_mock_courses(json_file_path):
+    with open(json_file_path, 'r') as file:
+        term_id = app.config['CURRENT_TERM_ID']
+        json_ = json.loads(file.read())
+        defaults = json_['defaults']
+        instructors = json_['instructors']
+        courses = []
+        for c in json_['courses']:
+            c['instructor_name'] = instructors[c['instructor_uid']]
+            c['meeting_end_date'] = app.config['CURRENT_TERM_END']
+            c['meeting_start_date'] = app.config['CURRENT_TERM_BEGIN']
+            c['term_id'] = term_id
+            for key, value in defaults.items():
+                if key not in c:
+                    c[key] = value
+            courses.append(c)
+        return courses
+
+
+def _save_courses(sis_sections):
+    now = utc_now().strftime('%Y-%m-%dT%H:%M:%S+00')
+    query = """
+        INSERT INTO sis_sections (
+            allowed_units, course_name, course_title, created_at, instruction_format, instructor_name,
+            instructor_role_code, instructor_uid, is_primary, meeting_days, meeting_end_date, meeting_end_time,
+            meeting_location, meeting_start_date, meeting_start_time, section_id, section_num, term_id
+        )
+        SELECT
+            allowed_units, course_name, course_title, created_at, instruction_format, instructor_name,
+            instructor_role_code, instructor_uid, is_primary, meeting_days, meeting_end_date, meeting_end_time,
+            meeting_location, meeting_start_date, meeting_start_time, section_id, section_num, term_id
+        FROM json_populate_recordset(null::sis_sections, :json_dumps)
+    """
+    data = [
+        {
+            'allowed_units': row['allowed_units'],
+            'course_name': row['course_name'],
+            'course_title': row['course_title'],
+            'created_at': now,
+            'instruction_format': row['instruction_format'],
+            'instructor_name': row['instructor_name'],
+            'instructor_role_code': row['instructor_role_code'],
+            'instructor_uid': row['instructor_uid'],
+            'is_primary': row['is_primary'],
+            'meeting_days': row['meeting_days'],
+            'meeting_end_date': row['meeting_end_date'],
+            'meeting_end_time': row['meeting_end_time'],
+            'meeting_location': row['meeting_location'],
+            'meeting_start_date': row['meeting_start_date'],
+            'meeting_start_time': row['meeting_start_time'],
+            'section_id': int(row['section_id']),
+            'section_num': row['section_num'],
+            'term_id': int(row['term_id']),
+        } for row in sis_sections
+    ]
+    db.session.execute(query, {'json_dumps': json.dumps(data)})

--- a/fixtures/sis/course_capture_pilot.json
+++ b/fixtures/sis/course_capture_pilot.json
@@ -1,0 +1,45 @@
+{
+  "defaults": {
+    "allowed_units": "4.0",
+    "instruction_format": "LEC",
+    "instructor_role_code": "PI",
+    "is_primary": true,
+    "section_num": "001"
+  },
+  "instructors": {
+    "1001": "Alexie Grady",
+    "1002": "Alexa Grady"
+  },
+  "courses": [
+    {
+      "instructor_uid": "1001",
+      "meeting_days": "MOWEFR",
+      "meeting_end_time": "14:59",
+      "meeting_location": "Cory 277",
+      "meeting_start_time": "14:00",
+      "course_name": "COMPSCI C8",
+      "course_title": "Foundations of Data Science",
+      "section_id": 60000
+    },
+    {
+      "instructor_uid": "1002",
+      "meeting_days": "MOWEFR",
+      "meeting_end_time": "14:59",
+      "meeting_location": "Cory 277",
+      "meeting_start_time": "14:00",
+      "course_name": "COMPSCI C8",
+      "course_title": "Foundations of Data Science",
+      "section_id": 60000
+    },
+    {
+      "instructor_uid": "1002",
+      "meeting_days": "TUTH",
+      "meeting_end_time": "8:59",
+      "meeting_location": "Evans 60",
+      "meeting_start_time": "8:00",
+      "course_name": "COMPSCI 61B",
+      "course_title": "Data Structures",
+      "section_id": 60001
+    }
+  ]
+}

--- a/fixtures/sis/courses.json
+++ b/fixtures/sis/courses.json
@@ -4,10 +4,7 @@
     "instruction_format": "LEC",
     "instructor_role_code": "PI",
     "is_primary": true,
-    "meeting_end_date": "2020-05-08 00:00:00 UTC",
-    "meeting_start_date": "2020-01-21 00:00:00 UTC",
-    "section_num": "001",
-    "term_id": 2202
+    "section_num": "001"
   },
   "instructors": {
     "10000": "Father Karras",

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -22,14 +22,24 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
-
+from diablo import std_commit
+from diablo.models.sis_section import SisSection
+from flask import current_app as app
 import pytest
 from tests.util import override_config
+
+admin_uid = '90001'
+instructor_uid = '10001'
 
 
 @pytest.fixture()
 def admin_session(fake_auth):
     fake_auth.login('90001')
+
+
+@pytest.fixture()
+def instructor_session(fake_auth):
+    fake_auth.login(instructor_uid)
 
 
 class TestVersion:
@@ -62,3 +72,33 @@ class TestConfigController:
             assert len(api_json['emailTemplateTypes'])
             assert len(api_json['roomCapabilityOptions'])
             assert len(api_json['searchFilterOptions'])
+
+
+class TestCourseCapturePilot:
+
+    @staticmethod
+    def _api_start_pilot(client, expected_status_code=200):
+        response = client.get('/api/config/start_course_capture_pilot')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_anonymous(self, client):
+        """Denies anonymous access."""
+        self._api_start_pilot(client, expected_status_code=401)
+
+    def test_unauthorized(self, client, instructor_session):
+        """Denies access if user is not an admin."""
+        self._api_start_pilot(client, expected_status_code=401)
+
+    def test_start_course_capture_pilot(self, client, admin_session):
+        """Admin can start Course Capture pilot."""
+        self._api_start_pilot(client)
+        std_commit(allow_test_environment=True)
+        # Verify
+        courses = SisSection.get_courses(
+            section_ids=[60000, 60001],
+            term_id=app.config['CURRENT_TERM_ID'],
+        )
+        assert len(courses) == 2
+        # You cannot hit the API a second time.
+        self._api_start_pilot(client, expected_status_code=500)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-380

After mock-course-data has been loaded, we will disable the SisImport job. If we add/remove courses in the file in S3 then we can reload by (1) run SisImport job and (2) hit `/api/start_course_capture_pilot` endpoint.