### PR TITLE
DIABLO-399, ami.config gets SECURITY_GROUP_AUTOSCALING env var

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -9,7 +9,7 @@ packages:
 
 option_settings:
   aws:autoscaling:launchconfiguration:
-    SSHSourceRestriction: tcp, 22, 22, sg-0a8a13d817cb48f85
+    SSHSourceRestriction: tcp, 22, 22, "$SECURITY_GROUP_AUTOSCALING"
 
   aws:elasticbeanstalk:application:
     Application Healthcheck URL: HTTPS:443/api/ping


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-399

I want to give this another try. Let's start with `aws:autoscaling:launchconfiguration`.