### PR TITLE
DIABLO-399, revert use of environment var in aws:autoscaling:launchconfiguration

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -9,7 +9,7 @@ packages:
 
 option_settings:
   aws:autoscaling:launchconfiguration:
-    SSHSourceRestriction: tcp, 22, 22, "$SECURITY_GROUP_AUTOSCALING"
+    SSHSourceRestriction: tcp, 22, 22, sg-0a8a13d817cb48f85
 
   aws:elasticbeanstalk:application:
     Application Healthcheck URL: HTTPS:443/api/ping


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-399

No dice. Back to the drawing board. The dev pipeline has been pointed back at repo master.
