### PR TITLE
DIABLO-415, sis_data_refresh deletes 'pilot' courses in sis_sections; we must delete related objects

### DIFF
--- a/diablo/api/config_controller.py
+++ b/diablo/api/config_controller.py
@@ -28,7 +28,7 @@ from diablo import __version__ as version
 from diablo.api.util import admin_required, get_search_filter_options
 from diablo.jobs.sis_data_refresh_job import SisDataRefreshJob
 from diablo.lib.berkeley import term_name_for_sis_id
-from diablo.lib.development_db_utils import load_mock_courses
+from diablo.lib.development_db_utils import save_mock_courses
 from diablo.lib.http import tolerant_jsonify
 from diablo.models.approval import NAMES_PER_PUBLISH_TYPE
 from diablo.models.email_template import EmailTemplate
@@ -78,7 +78,7 @@ def app_version():
 @app.route('/api/config/start_course_capture_pilot')
 @admin_required
 def course_capture_pilot():
-    load_mock_courses(app.config['COURSE_CAPTURE_PILOT_JSON'])
+    save_mock_courses(app.config['COURSE_CAPTURE_PILOT_JSON'])
     SisDataRefreshJob.after_sis_data_refresh(term_id=app.config['CURRENT_TERM_ID'])
     return tolerant_jsonify({'message': 'Success'}), 200
 

--- a/diablo/jobs/sis_data_refresh_job.py
+++ b/diablo/jobs/sis_data_refresh_job.py
@@ -27,6 +27,9 @@ from diablo.jobs.base_job import BaseJob
 from diablo.jobs.errors import BackgroundJobError
 from diablo.jobs.util import insert_or_update_instructors, refresh_cross_listings, refresh_rooms
 from diablo.lib.db import resolve_sql_template
+from diablo.lib.development_db_utils import load_pilot_courses
+from diablo.models.approval import Approval
+from diablo.models.scheduled import Scheduled
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
 
@@ -51,6 +54,12 @@ class SisDataRefreshJob(BaseJob):
 
     @classmethod
     def after_sis_data_refresh(cls, term_id):
+        for course in load_pilot_courses():
+            # Because sis_data_refresh deletes "pilot" courses in sis_sections, we must delete related objects.
+            section_id = course['section_id']
+            Approval.delete(term_id=course['term_id'], section_id=section_id)
+            Scheduled.delete(term_id=course['term_id'], section_id=section_id)
+
         distinct_instructor_uids = SisSection.get_distinct_instructor_uids()
         insert_or_update_instructors(distinct_instructor_uids)
         app.logger.info(f'{len(distinct_instructor_uids)} instructors updated')

--- a/diablo/lib/development_db_utils.py
+++ b/diablo/lib/development_db_utils.py
@@ -31,13 +31,17 @@ from diablo.models.sis_section import SisSection
 from flask import current_app as app
 
 
-def load_mock_courses(json_file_path):
+def save_mock_courses(json_file_path):
     courses = _load_mock_courses(json_file_path)
     if SisSection.get_course(term_id=courses[0]['term_id'], section_id=courses[0]['section_id']):
         raise InternalServerError(f'The course data in {json_file_path} has already been loaded')
     else:
         _save_courses(sis_sections=courses)
         std_commit(allow_test_environment=True)
+
+
+def load_pilot_courses():
+    return _load_mock_courses(app.config['COURSE_CAPTURE_PILOT_JSON'])
 
 
 def _load_mock_courses(json_file_path):

--- a/diablo/models/development_db.py
+++ b/diablo/models/development_db.py
@@ -29,7 +29,7 @@ from diablo import cache, db, std_commit
 from diablo.factory import background_job_manager
 from diablo.jobs.canvas_job import CanvasJob
 from diablo.jobs.sis_data_refresh_job import SisDataRefreshJob
-from diablo.lib.development_db_utils import load_mock_courses
+from diablo.lib.development_db_utils import save_mock_courses
 from diablo.lib.util import utc_now
 from diablo.models.admin_user import AdminUser
 from diablo.models.email_template import EmailTemplate
@@ -91,7 +91,7 @@ def _load_schemas():
 def _load_courses():
     term_id = app.config['CURRENT_TERM_ID']
     db.session.execute(SisSection.__table__.delete().where(SisSection.term_id == term_id))
-    load_mock_courses(f"{app.config['FIXTURES_PATH']}/sis/courses.json")
+    save_mock_courses(f"{app.config['FIXTURES_PATH']}/sis/courses.json")
     SisDataRefreshJob.after_sis_data_refresh(term_id=term_id)
     std_commit(allow_test_environment=True)
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-415

`instructor_emails_job` crashed because we had approvals for non-existent courses.