### PR TITLE
[release] DIABLO-399, security-groups on release branch; test shell script on benign entries in 00_ami.config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -1,6 +1,10 @@
 #
 # AWS configuration for Diablo
 #
+# Testing:
+# SECURITY_GROUP_AUTO_SCALING = ${SECURITY_GROUP_AUTO_SCALING}
+# SECURITY_GROUP_LOAD_BALANCER = ${SECURITY_GROUP_LOAD_BALANCER}
+#
 packages:
   yum:
     gcc-c++: []
@@ -9,7 +13,7 @@ packages:
 
 option_settings:
   aws:autoscaling:launchconfiguration:
-    SSHSourceRestriction: tcp, 22, 22, ${SECURITY_GROUP_AUTO_SCALING}
+    SSHSourceRestriction: tcp, 22, 22, sg-0a8bb4762304beedc
 
   aws:elasticbeanstalk:application:
     Application Healthcheck URL: HTTPS:443/api/ping
@@ -50,8 +54,8 @@ option_settings:
 
   # Load Balancer security group
   aws:elbv2:loadbalancer:
-    SecurityGroups: [${SECURITY_GROUP_LOAD_BALANCER}]
-    ManagedSecurityGroup: ${SECURITY_GROUP_LOAD_BALANCER}
+    SecurityGroups: [sg-0048170b7468fc90b]
+    ManagedSecurityGroup: sg-0048170b7468fc90b
 
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable

--- a/scripts/codebuild/assign-security-groups.sh
+++ b/scripts/codebuild/assign-security-groups.sh
@@ -5,7 +5,7 @@ set -e
 ami_config="${CODEBUILD_SRC_DIR}/.ebextensions/00_ami.config"
 tmp_file_path="${CODEBUILD_SRC_DIR}/00_ami.interpolated.config"
 
-if [ "$(git rev-parse --abbrev-ref HEAD)" = "release" ]; then
+if [ "${DIABLO_PROD_PIPELINE}" = "true" ]; then
   sed -e "s/\${SECURITY_GROUP_AUTO_SCALING}/sg-0a8bb4762304beedc/" \
       -e "s/\${SECURITY_GROUP_LOAD_BALANCER}/sg-0048170b7468fc90b/" \
       "${ami_config}" > "${tmp_file_path}"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-399

I've added env var `DIABLO_PROD_PIPELINE` to build stage of the prod pipeline.