### PR TITLE
NOJIRA, roll back Vuetify 2.3.0 to troubleshoot /jobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18874,9 +18874,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.0.tgz",
-      "integrity": "sha512-55lQr5878vACGD+jldcttpaGybZf4Qb1uo8WPdT97a179TuDCkPPxWEThRfMlgcpf5kfxae4c5ox+mfgmb/V6Q=="
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.34.tgz",
+      "integrity": "sha512-YE2gMGs2QvY/HsnVfUtYGoA6Nq7Pt6W7MuToJgSNMFmSHvCcjApZW39mebGKfVY2llLDbmrnL8d2AvOmUk8hcg=="
     },
     "vuetify-loader": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "vue": "2.6.11",
     "vue-moment": "4.1.0",
     "vue-router": "3.3.4",
-    "vuetify": "2.3.0",
+    "vuetify": "2.2.34",
     "vuex": "3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We'll see if Vuetify is to blame for sudden bad behavior on `/jobs`