### PR TITLE
DIABLO-399, restore env vars in 00_ami.config; the replace-token script verified in previous PR

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -1,10 +1,6 @@
 #
 # AWS configuration for Diablo
 #
-# Testing:
-# SECURITY_GROUP_AUTO_SCALING = ${SECURITY_GROUP_AUTO_SCALING}
-# SECURITY_GROUP_LOAD_BALANCER = ${SECURITY_GROUP_LOAD_BALANCER}
-#
 packages:
   yum:
     gcc-c++: []
@@ -13,7 +9,7 @@ packages:
 
 option_settings:
   aws:autoscaling:launchconfiguration:
-    SSHSourceRestriction: tcp, 22, 22, sg-0a8a13d817cb48f85
+    SSHSourceRestriction: tcp, 22, 22, ${SECURITY_GROUP_AUTO_SCALING}
 
   aws:elasticbeanstalk:application:
     Application Healthcheck URL: HTTPS:443/api/ping
@@ -54,8 +50,8 @@ option_settings:
 
   # Load Balancer security group
   aws:elbv2:loadbalancer:
-    SecurityGroups: [sg-0563c2648b0b301eb]
-    ManagedSecurityGroup: sg-0563c2648b0b301eb
+    SecurityGroups: [${SECURITY_GROUP_LOAD_BALANCER}]
+    ManagedSecurityGroup: ${SECURITY_GROUP_LOAD_BALANCER}
 
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-399

PR #289 was merged and deployed to prod successfully; the `scripts/codebuild/assign-security-groups.sh` picked up the new CodeBuild env var, as hoped. I expect it to work properly in non-prod environments, too.  This PR is that final step.