### PR TITLE
DIABLO-364, reduce complexity in Jobs.vue; async job run without 'schedule'

### DIFF
--- a/diablo/jobs/base_job.py
+++ b/diablo/jobs/base_job.py
@@ -29,14 +29,12 @@ from diablo.merged.emailer import send_system_error_email
 from diablo.models.job import Job
 from diablo.models.job_history import JobHistory
 from flask import current_app as app
-import schedule
 
 
 class BaseJob:
 
-    def __init__(self, app_context, run_once=False):
+    def __init__(self, app_context):
         self.app_context = app_context
-        self.run_once = run_once
 
     def run(self, force_run=False):
         with self.app_context():
@@ -68,8 +66,6 @@ class BaseJob:
                         )
             else:
                 raise BackgroundJobError(f'Job {self.key()} is not registered in the database')
-        if self.run_once:
-            return schedule.CancelJob
 
     def _run(self):
         raise BackgroundJobError('Implement this method in Job sub-class')

--- a/diablo/models/job_history.py
+++ b/diablo/models/job_history.py
@@ -78,10 +78,6 @@ class JobHistory(db.Model):
         days_ago = datetime.now() - timedelta(days=day_count)
         return cls.query.filter(cls.started_at >= days_ago).order_by(desc(cls.started_at)).all()
 
-    @classmethod
-    def get_running_jobs(cls):
-        return cls.query.filter_by(finished_at=None).all()
-
     @staticmethod
     def fail_orphans():
         sql = """

--- a/package-lock.json
+++ b/package-lock.json
@@ -18874,9 +18874,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.34.tgz",
-      "integrity": "sha512-YE2gMGs2QvY/HsnVfUtYGoA6Nq7Pt6W7MuToJgSNMFmSHvCcjApZW39mebGKfVY2llLDbmrnL8d2AvOmUk8hcg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.0.tgz",
+      "integrity": "sha512-55lQr5878vACGD+jldcttpaGybZf4Qb1uo8WPdT97a179TuDCkPPxWEThRfMlgcpf5kfxae4c5ox+mfgmb/V6Q=="
     },
     "vuetify-loader": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "vue": "2.6.11",
     "vue-moment": "4.1.0",
     "vue-router": "3.3.4",
-    "vuetify": "2.2.34",
+    "vuetify": "2.3.0",
     "vuex": "3.4.0"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
     "vue-cli-plugin-vuetify": "^2.0.5",
     "vue-eslint-parser": "^7.1.0",
     "vue-template-compiler": "^2.6.11",
-    "vuetify-loader": "^1.4.4"
+    "vuetify-loader": "^1.5.0"
   },
   "license": "SEE LICENSE IN LICENSE",
   "repository": {

--- a/src/api/job.ts
+++ b/src/api/job.ts
@@ -9,10 +9,6 @@ export function getJobSchedule() {
   return axios.get(`${utils.apiBaseUrl()}/api/job/schedule`)
 }
 
-export function getRunningJobs() {
-  return axios.get(`${utils.apiBaseUrl()}/api/jobs/running`)
-}
-
 export function setJobDisabled(jobId, disable) {
   return axios.post(`${utils.apiBaseUrl()}/api/job/disable`, {
     jobId,

--- a/src/components/job/JobHistory.vue
+++ b/src/components/job/JobHistory.vue
@@ -19,6 +19,7 @@
       hide-default-footer
       :items="jobHistory"
       :loading="refreshing"
+      no-data-text="Job history is empty"
       no-results-text="No matching jobs"
       :options="options"
       :page.sync="options.page"
@@ -73,70 +74,39 @@
 
 <script>
   import Context from '@/mixins/Context'
-  import {getJobHistory} from '@/api/job'
 
   export default {
     name: 'JobHistory',
     mixins: [Context],
     props: {
-      ping: {
-        default: undefined,
-        required: false,
-        type: Number
+      jobHistory: {
+        required: true,
+        type: Array
+      },
+      refreshing: {
+        required: true,
+        type: Boolean
       }
     },
     data: () => ({
       dateFormat: 'dddd, MMMM Do, h:mm:ss a',
-      daysCount: 3,
       headers: [
         {text: 'Key', value: 'jobKey'},
         {text: 'Status', value: 'failed'},
         {text: 'Started', value: 'startedAt'},
         {text: 'Finished', value: 'finishedAt'}
       ],
-      jobHistory: undefined,
       options: {
         page: 1,
         itemsPerPage: 50
       },
       pageCount: undefined,
-      refresher: undefined,
-      refreshing: false,
       richardPryor: false,
       search: undefined
     }),
     watch: {
-      ping(value) {
-        if (value && !this.refreshing) {
-          this.refresh()
-        }
-      },
       search(value) {
         this.richardPryor = value && value.toLowerCase() === 'the bed is on my foot'
-      }
-    },
-    created() {
-      this.refresh()
-    },
-    destroyed() {
-      clearTimeout(this.refresher)
-    },
-    methods: {
-      refresh() {
-        this.refreshing = true
-        return getJobHistory(this.daysCount).then(data => {
-          this.jobHistory = data
-          this.refreshing = false
-          if (!this.loading) {
-            this.alertScreenReader('Job History refreshed')
-          }
-          this.scheduleRefresh()
-        })
-      },
-      scheduleRefresh() {
-        // Clear previous job, if pending
-        clearTimeout(this.refresher)
-        this.refresher = setTimeout(this.refresh, 5000)
       }
     }
   }

--- a/src/components/util/Snackbar.vue
+++ b/src/components/util/Snackbar.vue
@@ -3,22 +3,29 @@
     v-model="snackbarShow"
     :color="snackbar.color"
     :timeout="snackbar.timeout"
+    content-class="align-center"
     :top="true"
   >
-    <span
-      id="alert-text"
-      aria-live="polite"
-      role="alert"
-      class="title"
-    >{{ snackbar.text }}</span>
-    <v-btn
-      id="btn-close-alert"
-      aria-label="Close this dialog box."
-      text
-      @click="snackbarClose"
-    >
-      Close
-    </v-btn>
+    <div class="d-flex align-center justify-space-between">
+      <div
+        id="alert-text"
+        aria-live="polite"
+        class="ml-4 mr-4 title"
+        role="alert"
+      >
+        {{ snackbar.text }}
+      </div>
+      <div>
+        <v-btn
+          id="btn-close-alert"
+          aria-label="Close this dialog box."
+          text
+          @click="snackbarClose"
+        >
+          Close
+        </v-btn>
+      </div>
+    </div>
   </v-snackbar>
 </template>
 

--- a/src/views/BaseView.vue
+++ b/src/views/BaseView.vue
@@ -96,13 +96,13 @@
         </v-list>
       </v-menu>
     </v-app-bar>
-    <v-content>
+    <v-main>
       <div class="ma-3">
         <Snackbar />
         <Spinner v-if="loading" />
         <router-view id="content" :key="$route.fullPath"></router-view>
       </div>
-    </v-content>
+    </v-main>
     <Footer />
   </v-app>
 </template>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -2,7 +2,7 @@
   <v-app :id="$vuetify.theme.dark ? 'dark' : 'light'">
     <Snackbar />
     <v-container class="background-splash" fill-height fluid>
-      <v-content>
+      <v-main>
         <v-card
           class="mx-auto opaque-card"
           elevation="24"
@@ -74,7 +74,7 @@
             </v-row>
           </v-container>
         </v-card>
-      </v-content>
+      </v-main>
     </v-container>
   </v-app>
 </template>

--- a/tests/test_api/test_job_controller.py
+++ b/tests/test_api/test_job_controller.py
@@ -247,27 +247,6 @@ class TestUpdateJobSchedule:
         }
 
 
-class TestRunningJobs:
-
-    @staticmethod
-    def _api_jobs_running(client, expected_status_code=200):
-        response = client.get('/api/jobs/running')
-        assert response.status_code == expected_status_code
-        return response.json
-
-    def test_anonymous(self, client):
-        """Denies anonymous access."""
-        self._api_jobs_running(client, expected_status_code=401)
-
-    def test_unauthorized(self, client, instructor_session):
-        """Denies access if user is not an admin."""
-        self._api_jobs_running(client, expected_status_code=401)
-
-    def test_authorized(self, client, admin_session):
-        """Admin can see running obs."""
-        self._api_jobs_running(client)
-
-
 class TestJobSchedule:
 
     @staticmethod

--- a/xena/pages/jobs_page.py
+++ b/xena/pages/jobs_page.py
@@ -101,7 +101,7 @@ class JobsPage(DiabloPages):
         self.wait_for_most_recent_job_success(AsyncJob.SIS_DATA_REFRESH)
 
     def wait_for_jobs_table(self):
-        locator = By.XPATH, '//h2[contains(text(), "Job Schedule")]/../../following-sibling::div//table'
+        locator = By.XPATH, '//h2[contains(text(), "Jobs")]/../../following-sibling::div//table'
         Wait(self.driver, util.get_short_timeout()).until(ec.visibility_of_element_located(locator))
 
     @staticmethod


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-364

* some front-end weirdness was caused by use of `schedule` in controller
* simplify: toss out `/api/jobs/running` and rely on jobHistory to deduce `job.isRunning` 
* restore vuetify v2.3.0 which was not to blame