### PR TITLE
DIABLO-364, sis_refresh_job takes ~2 min to finish; bump Apache timeout to 3 min

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -67,6 +67,8 @@ files:
           group=wsgi
         WSGIProcessGroup wsgi-ssl
 
+        TimeOut 300
+
       </VirtualHost>
 
   # Load-balancer expects this SSL certificate on EC2 instances.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-364

The goal: no HTTP 504 error when invoking `/api/job/sis_refresh_job/start`  from `/jobs` page. From the client-side, we make that API call in async fashion. 