### PR TITLE
DIABLO-432, test course data with dual-mode and hybrid instruction

### DIFF
--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -679,6 +679,7 @@ def _to_api_json(term_id, rows, include_rooms=True):
                 meeting['eligible'] = False
             if include_rooms:
                 meeting['room'] = room.to_api_json() if room else None
+        course['meetings'] = sorted(course['meetings'], key=lambda m: f"{m['startDate']} {m['startTime']}")
 
     # Next, construct the feed
     api_json = []

--- a/fixtures/sis/courses.json
+++ b/fixtures/sis/courses.json
@@ -247,6 +247,90 @@
       "course_title": "Linear algebra and differential calculus",
       "instruction_format": "COL",
       "section_id": 50013
+    },
+    {
+      "instructor_uid": "10004",
+      "meeting_days": "MOWEFR",
+      "meeting_end_date": "2020-11-06",
+      "meeting_end_time": "23:59",
+      "meeting_location": "Internet/Online",
+      "meeting_start_date": "2020-10-05",
+      "meeting_start_time": "23:00",
+      "course_name": "PHYSICS 7A LEC 001 (dual mode instruction)",
+      "course_title": "Physics for Scientists and Engineers",
+      "section_id": 50014
+    },
+    {
+      "instructor_uid": "10004",
+      "meeting_days": "MOWEFR",
+      "meeting_end_date": "2020-10-02",
+      "meeting_end_time": "08:59",
+      "meeting_location": "LeConte 1",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "08:00",
+      "course_name": "PHYSICS 7A LEC 001 (dual mode instruction)",
+      "course_title": "Physics for Scientists and Engineers",
+      "section_id": 50014
+    },
+    {
+      "instructor_uid": "10004",
+      "meeting_days": "MOWEFR",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "08:59",
+      "meeting_location": "LeConte 1",
+      "meeting_start_date": "2020-11-09",
+      "meeting_start_time": "08:00",
+      "course_name": "PHYSICS 7A LEC 001 (dual mode instruction)",
+      "course_title": "Physics for Scientists and Engineers",
+      "section_id": 50014
+    },
+    {
+      "instructor_uid": "10003",
+      "meeting_days": "MOWEFR",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "13:59",
+      "meeting_location": "Barker 101",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "13:00",
+      "course_name": "PHYSICS 7A (hybrid instruction)",
+      "course_title": "Physics for Scientists and Engineers",
+      "section_id": 50015
+    },
+    {
+      "instructor_uid": "10003",
+      "meeting_days": "TUTH",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "15:29",
+      "meeting_location": "LeConte 1",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "14:00",
+      "course_name": "PHYSICS 7A (hybrid instruction)",
+      "course_title": "Physics for Scientists and Engineers",
+      "section_id": 50015
+    },
+    {
+      "instructor_uid": "10005",
+      "meeting_days": "WE",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "08:59",
+      "meeting_location": "Dwinelle 155",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "08:00",
+      "course_name": "COMPSCI 161 LEC 001 (hybrid instruction)",
+      "course_title": "Computer Security",
+      "section_id": 50016
+    },
+    {
+      "instructor_uid": "10005",
+      "meeting_days": "TUTH",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "19:59",
+      "meeting_location": "Pimentel 1",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "18:30",
+      "course_name": "COMPSCI 161 LEC 001 (hybrid instruction)",
+      "course_title": "Computer Security",
+      "section_id": 50016
     }
   ]
 }

--- a/tests/test_jobs/test_invitation_job.py
+++ b/tests/test_jobs/test_invitation_job.py
@@ -47,11 +47,11 @@ class TestInvitationJob:
             # Emails are sent. We have more emails than courses since some courses have multiple instructors.
             QueuedEmailsJob(simply_yield).run()
             invitations = _get_invitations_since(term_id, timestamp)
-            assert len(invitations) == 12
+            assert len(invitations) == 13
 
             # Each eligible course has an invitation.
             eligible_courses = SisSection.get_courses(term_id=term_id)
-            assert len(eligible_courses) == 8
+            assert len(eligible_courses) == 9
             for course in eligible_courses:
                 for i in course['instructors']:
                     sent_email = next((e for e in invitations if e.section_id == course['sectionId'] and i['uid'] == e.recipient_uid), None)
@@ -97,7 +97,7 @@ class TestInvitationJob:
             # Emails are sent.
             QueuedEmailsJob(simply_yield).run()
             invitations = _get_invitations_since(term_id, timestamp)
-            assert len(invitations) == 13
+            assert len(invitations) == 14
             assert not next((e for e in invitations if e.section_id == section_id), None)
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-432

'meetings' are ordered by 'startDate', 'startTime'.  I will add similar mock data to our _pilot.json_ in S3.