### PR TITLE
DIABLO-413, email template: admin_alert_date_change; scheduled table gets start/end dates

### DIFF
--- a/diablo/lib/kaltura_util.py
+++ b/diablo/lib/kaltura_util.py
@@ -26,7 +26,6 @@ from datetime import datetime, timedelta
 import json
 
 from diablo.lib.util import default_timezone, epoch_time_to_isoformat
-from flask import current_app as app
 from KalturaClient.Plugins.Schedule import KalturaBlackoutScheduleEvent, KalturaScheduleEventClassificationType, \
     KalturaScheduleEventRecurrenceType, KalturaScheduleEventStatus
 
@@ -116,8 +115,7 @@ def get_recurrence_name(recurrence_type):
     }[recurrence_type.value]
 
 
-def get_first_matching_datetime_of_term(meeting_days, time_hours, time_minutes):
-    start_date = datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d')
+def get_first_matching_datetime_of_term(meeting_days, start_date, time_hours, time_minutes):
     first_meeting = None
     meeting_day_indices = [DAYS.index(day) for day in meeting_days]
     for index in range(7):

--- a/diablo/models/email_template.py
+++ b/diablo/models/email_template.py
@@ -29,6 +29,7 @@ from sqlalchemy.dialects.postgresql import ENUM
 
 
 email_template_type = ENUM(
+    'admin_alert_date_change',
     'admin_alert_instructor_change',
     'admin_alert_multiple_meeting_patterns',
     'admin_alert_room_change',
@@ -120,6 +121,7 @@ class EmailTemplate(Base):
     def get_template_type_options(cls):
         return {
             'admin_alert_instructor_change': 'Admin alert: Instructor change',
+            'admin_alert_date_change': 'Admin alert: Date change',
             'admin_alert_multiple_meeting_patterns': 'Admin alert: Weird start/end dates',
             'admin_alert_room_change': 'Admin alert: Room change',
             'invitation': 'Invitation',

--- a/diablo/models/scheduled.py
+++ b/diablo/models/scheduled.py
@@ -41,8 +41,10 @@ class Scheduled(db.Model):
     instructor_uids = db.Column(ARRAY(db.String(80)), nullable=False)
     kaltura_schedule_id = db.Column(db.Integer, nullable=False)
     meeting_days = db.Column(db.String, nullable=False)
-    meeting_start_time = db.Column(db.String, nullable=False)
+    meeting_end_date = db.Column(db.String, nullable=False)
     meeting_end_time = db.Column(db.String, nullable=False)
+    meeting_start_date = db.Column(db.String, nullable=False)
+    meeting_start_time = db.Column(db.String, nullable=False)
     publish_type = db.Column(publish_type, nullable=False)
     recording_type = db.Column(recording_type, nullable=False)
     room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'), nullable=False)
@@ -56,8 +58,10 @@ class Scheduled(db.Model):
             instructor_uids,
             kaltura_schedule_id,
             meeting_days,
-            meeting_start_time,
+            meeting_end_date,
             meeting_end_time,
+            meeting_start_date,
+            meeting_start_time,
             publish_type_,
             recording_type_,
             room_id,
@@ -67,8 +71,10 @@ class Scheduled(db.Model):
         self.instructor_uids = instructor_uids
         self.kaltura_schedule_id = kaltura_schedule_id
         self.meeting_days = meeting_days
-        self.meeting_start_time = meeting_start_time
+        self.meeting_end_date = meeting_end_date
         self.meeting_end_time = meeting_end_time
+        self.meeting_start_date = meeting_start_date
+        self.meeting_start_time = meeting_start_time
         self.publish_type = publish_type_
         self.recording_type = recording_type_
         self.room_id = room_id
@@ -81,8 +87,10 @@ class Scheduled(db.Model):
                     instructor_uids={', '.join(self.instructor_uids)},
                     kaltura_schedule_id={self.kaltura_schedule_id}
                     meeting_days={self.meeting_days},
-                    meeting_start_time={self.meeting_start_time},
+                    meeting_end_date={self.meeting_end_date},
                     meeting_end_time={self.meeting_end_time},
+                    meeting_start_date={self.meeting_start_date},
+                    meeting_start_time={self.meeting_start_time},
                     publish_type={self.publish_type},
                     recording_type={self.recording_type},
                     room_id={self.room_id},
@@ -97,8 +105,10 @@ class Scheduled(db.Model):
             instructor_uids,
             kaltura_schedule_id,
             meeting_days,
-            meeting_start_time,
+            meeting_end_date,
             meeting_end_time,
+            meeting_start_date,
+            meeting_start_time,
             publish_type_,
             recording_type_,
             room_id,
@@ -107,8 +117,10 @@ class Scheduled(db.Model):
             instructor_uids=instructor_uids,
             kaltura_schedule_id=kaltura_schedule_id,
             meeting_days=meeting_days,
-            meeting_start_time=meeting_start_time,
+            meeting_end_date=meeting_end_date,
             meeting_end_time=meeting_end_time,
+            meeting_start_date=meeting_start_date,
+            meeting_start_time=meeting_start_time,
             publish_type_=publish_type_,
             recording_type_=recording_type_,
             room_id=room_id,
@@ -150,7 +162,9 @@ class Scheduled(db.Model):
             'instructorUids': self.instructor_uids,
             'kalturaScheduleId': self.kaltura_schedule_id,
             'meetingDays': format_days(self.meeting_days),
+            'meetingEndDate': self.meeting_end_date,
             'meetingEndTime': format_time(self.meeting_end_time),
+            'meetingStartDate': self.meeting_start_date,
             'meetingStartTime': format_time(self.meeting_start_time),
             'publishType': self.publish_type,
             'publishTypeName': NAMES_PER_PUBLISH_TYPE[self.publish_type],

--- a/scripts/db/migrate/2020/20200623-DIABLO-413/admin_alert_date_change_template_type.sql
+++ b/scripts/db/migrate/2020/20200623-DIABLO-413/admin_alert_date_change_template_type.sql
@@ -1,0 +1,52 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+-- Rename existing TYPE
+ALTER TYPE email_template_types RENAME TO email_template_types_OLD;
+
+-- Create new TYPE
+CREATE TYPE email_template_types AS ENUM (
+    'admin_alert_date_change',
+    'admin_alert_instructor_change',
+    'admin_alert_multiple_meeting_patterns',
+    'admin_alert_room_change',
+    'invitation',
+    'notify_instructor_of_changes',
+    'recordings_scheduled',
+    'room_change_no_longer_eligible',
+    'waiting_for_approval'
+);
+
+-- Update tables to use the new TYPE
+ALTER TABLE email_templates ALTER COLUMN template_type TYPE email_template_types USING template_type::text::email_template_types;
+ALTER TABLE queued_emails ALTER COLUMN template_type TYPE email_template_types USING template_type::text::email_template_types;
+ALTER TABLE sent_emails ALTER COLUMN template_type TYPE email_template_types USING template_type::text::email_template_types;
+
+-- Remove old TYPE
+DROP TYPE email_template_types_OLD;
+
+COMMIT;

--- a/scripts/db/migrate/2020/20200623-DIABLO-413/alter_scheduled_add_start_end_dates.sql
+++ b/scripts/db/migrate/2020/20200623-DIABLO-413/alter_scheduled_add_start_end_dates.sql
@@ -1,0 +1,37 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+DELETE FROM scheduled;
+
+ALTER TABLE scheduled ALTER COLUMN meeting_days SET NOT NULL;
+ALTER TABLE scheduled ALTER COLUMN meeting_end_time SET NOT NULL;
+ALTER TABLE scheduled ALTER COLUMN meeting_start_time SET NOT NULL;
+
+ALTER TABLE scheduled ADD COLUMN meeting_end_date VARCHAR(80) NOT NULL;
+ALTER TABLE scheduled ADD COLUMN meeting_start_date VARCHAR(80) NOT NULL;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -46,6 +46,7 @@ CREATE TYPE approver_types AS ENUM (
 --
 
 CREATE TYPE email_template_types AS ENUM (
+    'admin_alert_date_change',
     'admin_alert_instructor_change',
     'admin_alert_multiple_meeting_patterns',
     'admin_alert_room_change',
@@ -309,9 +310,11 @@ CREATE TABLE scheduled (
     term_id INTEGER NOT NULL,
     instructor_uids VARCHAR(80)[] NOT NULL,
     kaltura_schedule_id INTEGER NOT NULL,
-    meeting_days VARCHAR(80),
-    meeting_end_time VARCHAR(80),
-    meeting_start_time VARCHAR(80),
+    meeting_days VARCHAR(80) NOT NULL,
+    meeting_end_date VARCHAR(80) NOT NULL,
+    meeting_end_time VARCHAR(80) NOT NULL,
+    meeting_start_date VARCHAR(80) NOT NULL,
+    meeting_start_time VARCHAR(80) NOT NULL,
     publish_type publish_types NOT NULL,
     recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,

--- a/src/components/course/CoursePageSidebar.vue
+++ b/src/components/course/CoursePageSidebar.vue
@@ -19,7 +19,7 @@
         <v-col :class="{'pb-0': course.displayMeetings.length > 1}">
           {{ $_.join(meeting.daysFormatted, ', ') }}
           <div v-if="course.meetingDateRangesVary">
-            {{ meeting.startDate | moment('MMM D, YYYY')}} to {{ meeting.endDate | moment('MMM D, YYYY')}}
+            {{ meeting.startDate | moment('MMM D, YYYY') }} to {{ meeting.endDate | moment('MMM D, YYYY') }}
           </div>
         </v-col>
       </v-row>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -59,8 +59,8 @@
               </td>
               <td class="text-no-wrap">
                 <div v-if="course.meetingDateRangesVary" class="pt-2">
-                  <span class="text-no-wrap">{{ course.meetings.eligible[index].startDate | moment('MMM D, YYYY')}} - </span>
-                  <span class="text-no-wrap">{{ course.meetings.eligible[index].endDate | moment('MMM D, YYYY')}}</span>
+                  <span class="text-no-wrap">{{ course.meetings.eligible[index].startDate | moment('MMM D, YYYY') }} - </span>
+                  <span class="text-no-wrap">{{ course.meetings.eligible[index].endDate | moment('MMM D, YYYY') }}</span>
                 </div>
                 <div :class="{'pb-2': course.meetingDateRangesVary && index === course.meetings.eligible.length - 1}">
                   {{ course.meetings.eligible[index].startTimeFormatted }} - {{ course.meetings.eligible[index].endTimeFormatted }}

--- a/tests/test_api/api_test_utils.py
+++ b/tests/test_api/api_test_utils.py
@@ -62,10 +62,9 @@ def api_get_course(client, term_id, section_id, expected_status_code=200):
     return response.json
 
 
-def get_meeting_data(term_id, section_id):
+def get_eligible_meeting(section_id, term_id):
     feed = SisSection.get_course(term_id=term_id, section_id=section_id)
-    meeting = (feed['meetings']['eligible'] + feed['meetings']['ineligible'])[0]
-    return meeting['days'], meeting['startTime'], meeting['endTime']
+    return (feed['meetings']['eligible'] + feed['meetings']['ineligible'])[0]
 
 
 @cachify('instructor_uids_{section_id}_{term_id}')

--- a/tests/test_jobs/test_email_alerts_for_admins.py
+++ b/tests/test_jobs/test_email_alerts_for_admins.py
@@ -38,7 +38,7 @@ from diablo.models.sent_email import SentEmail
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
 import pytest
-from tests.test_api.api_test_utils import get_instructor_uids, get_meeting_data
+from tests.test_api.api_test_utils import get_eligible_meeting, get_instructor_uids
 from tests.util import simply_yield, test_approvals_workflow
 
 
@@ -69,16 +69,15 @@ class TestEmailAlertsForAdmins:
                 section_id=section_id,
                 term_id=term_id,
             )
-            meeting_days, meeting_start_time, meeting_end_time = get_meeting_data(
-                term_id=term_id,
-                section_id=section_id,
-            )
+            meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
             Scheduled.create(
                 instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
                 kaltura_schedule_id=random.randint(1, 10),
-                meeting_days=meeting_days,
-                meeting_start_time=meeting_start_time,
-                meeting_end_time=meeting_end_time,
+                meeting_days=meeting['days'],
+                meeting_end_date=meeting['endDate'],
+                meeting_end_time=meeting['endTime'],
+                meeting_start_date=meeting['startDate'],
+                meeting_start_time=meeting['startTime'],
                 publish_type_=approval.publish_type,
                 recording_type_=approval.recording_type,
                 room_id=scheduled_in_room.id,
@@ -101,10 +100,6 @@ class TestEmailAlertsForAdmins:
             term_id = app.config['CURRENT_TERM_ID']
             section_id = 50005
             room_id = Room.find_room('Barker 101').id
-            meeting_days, meeting_start_time, meeting_end_time = get_meeting_data(
-                term_id=term_id,
-                section_id=section_id,
-            )
             # The course has two instructors.
             instructor_1_uid, instructor_2_uid = get_instructor_uids(section_id=section_id, term_id=term_id)
             approval = Approval.create(
@@ -117,12 +112,15 @@ class TestEmailAlertsForAdmins:
                 term_id=term_id,
             )
             # Uh oh! Only one of them has been scheduled.
+            meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
             Scheduled.create(
                 instructor_uids=[instructor_1_uid],
                 kaltura_schedule_id=random.randint(1, 10),
-                meeting_days=meeting_days,
-                meeting_start_time=meeting_start_time,
-                meeting_end_time=meeting_end_time,
+                meeting_days=meeting['days'],
+                meeting_end_date=meeting['endDate'],
+                meeting_end_time=meeting['endTime'],
+                meeting_start_date=meeting['startDate'],
+                meeting_start_time=meeting['startTime'],
                 publish_type_=approval.publish_type,
                 recording_type_=approval.recording_type,
                 room_id=room_id,
@@ -148,10 +146,6 @@ class TestEmailAlertsForAdmins:
             term_id = app.config['CURRENT_TERM_ID']
             section_id = 50014
             room_id = Room.find_room('Barker 101').id
-            meeting_days, meeting_start_time, meeting_end_time = get_meeting_data(
-                term_id=term_id,
-                section_id=section_id,
-            )
             # The course has two instructors.
             instructor_uid = get_instructor_uids(section_id=section_id, term_id=term_id)[0]
             approval = Approval.create(
@@ -164,12 +158,15 @@ class TestEmailAlertsForAdmins:
                 term_id=term_id,
             )
             # Uh oh! Only one of them has been scheduled.
+            meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
             Scheduled.create(
                 instructor_uids=[instructor_uid],
                 kaltura_schedule_id=random.randint(1, 10),
-                meeting_days=meeting_days,
-                meeting_start_time=meeting_start_time,
-                meeting_end_time=meeting_end_time,
+                meeting_days=meeting['days'],
+                meeting_end_date=meeting['endDate'],
+                meeting_end_time=meeting['endTime'],
+                meeting_start_date=meeting['startDate'],
+                meeting_start_time=meeting['startTime'],
                 publish_type_=approval.publish_type,
                 recording_type_=approval.recording_type,
                 room_id=room_id,

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -22,33 +22,21 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
+from diablo.lib.berkeley import get_recording_end_date, get_recording_start_date
 from flask import current_app as app
+from tests.util import override_config
 
 
-def flatten_location(name):
-    return name and ''.join(name.split()).lower()
+class TestRecordingDates:
 
+    def test_recording_end_date(self):
+        diablo_end = '2020-11-25'
+        with override_config(app, 'CURRENT_TERM_END', diablo_end):
+            assert get_recording_end_date(meeting={'endDate': '2020-12-11'}) == diablo_end
+            assert get_recording_end_date(meeting={'endDate': '2020-11-01'}) == '2020-11-01'
 
-def get_recording_end_date(meeting):
-    actual_end = meeting['endDate']
-    diablo_end = app.config['CURRENT_TERM_END']
-    return actual_end if actual_end < diablo_end else diablo_end
-
-
-def get_recording_start_date(meeting):
-    actual_start = meeting['startDate']
-    diablo_start = app.config['CURRENT_TERM_BEGIN']
-    return actual_start if actual_start > diablo_start else diablo_start
-
-
-def term_name_for_sis_id(sis_id=None):
-    if sis_id:
-        sis_id = str(sis_id)
-        season_codes = {
-            '0': 'Winter',
-            '2': 'Spring',
-            '5': 'Summer',
-            '8': 'Fall',
-        }
-        year = f'19{sis_id[1:3]}' if sis_id.startswith('1') else f'20{sis_id[1:3]}'
-        return f'{season_codes[sis_id[3:4]]} {year}'
+    def test_recording_start_date(self):
+        diablo_start = '2020-09-07'
+        with override_config(app, 'CURRENT_TERM_BEGIN', diablo_start):
+            assert get_recording_start_date(meeting={'startDate': '2020-08-26'}) == diablo_start
+            assert get_recording_start_date(meeting={'startDate': '2020-09-14'}) == '2020-09-14'

--- a/tests/test_lib/test_kaltura_util.py
+++ b/tests/test_lib/test_kaltura_util.py
@@ -22,6 +22,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
+from datetime import datetime
+
 from diablo.lib.kaltura_util import get_first_matching_datetime_of_term
 from flask import current_app as app
 import pytz
@@ -35,6 +37,7 @@ class TestFirstDayRecording:
         with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
             first_day_start = get_first_matching_datetime_of_term(
                 meeting_days=['MO', 'WE', 'FR'],
+                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
                 time_hours=13,
                 time_minutes=30,
             )
@@ -45,6 +48,7 @@ class TestFirstDayRecording:
         with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
             first_day_start = get_first_matching_datetime_of_term(
                 meeting_days=['TU', 'TH'],
+                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
                 time_hours=13,
                 time_minutes=30,
             )
@@ -55,6 +59,7 @@ class TestFirstDayRecording:
         with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
             first_day_start = get_first_matching_datetime_of_term(
                 meeting_days=['MO', 'TU'],
+                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
                 time_hours=8,
                 time_minutes=45,
             )
@@ -65,6 +70,7 @@ class TestFirstDayRecording:
         with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
             first_day_start = get_first_matching_datetime_of_term(
                 meeting_days=['TU'],
+                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
                 time_hours=9,
                 time_minutes=15,
             )
@@ -76,6 +82,7 @@ class TestFirstDayRecording:
         with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
             first_day_start = get_first_matching_datetime_of_term(
                 meeting_days=['TU', 'TH'],
+                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
                 time_hours=9,
                 time_minutes=37,
             )


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-413

* Start and end dates of a recording are reconciled with (1) dates of meeting and (2) global start/end in Diablo configs.
* The `scheduled` table get `meeting_end_date` and `meeting_start_date` columns
* New email template: admin_alert_date_change