### PR TITLE
DIABLO-444 Display meeting date changes on Course Changes page

### DIFF
--- a/src/components/course/CoursePageSidebar.vue
+++ b/src/components/course/CoursePageSidebar.vue
@@ -18,7 +18,7 @@
         </v-col>
         <v-col :class="{'pb-0': course.displayMeetings.length > 1}">
           {{ $_.join(meeting.daysFormatted, ', ') }}
-          <div v-if="course.meetingDateRangesVary">
+          <div v-if="course.nonstandardMeetingDates">
             {{ meeting.startDate | moment('MMM D, YYYY') }} to {{ meeting.endDate | moment('MMM D, YYYY') }}
           </div>
         </v-col>

--- a/src/components/course/CoursesDataTable.vue
+++ b/src/components/course/CoursesDataTable.vue
@@ -65,7 +65,7 @@
                 {{ $_.join(meetings(course)[0].daysFormatted, ', ') || '&mdash;' }}
               </td>
               <td :id="`meeting-times-${course.sectionId}-0`" :class="tdc(course)">
-                <div v-if="course.meetingDateRangesVary">
+                <div v-if="course.nonstandardMeetingDates">
                   <span class="text-no-wrap">{{ meetings(course)[0].startDate | moment('MMM D, YYYY') }} - </span>
                   <span class="text-no-wrap">{{ meetings(course)[0].endDate | moment('MMM D, YYYY') }}</span>
                 </div>
@@ -138,11 +138,11 @@
                 {{ $_.join(meetings(course)[index].daysFormatted, ', ') || '&mdash;' }}
               </td>
               <td class="text-no-wrap" :class="mdc(course)">
-                <div v-if="course.meetingDateRangesVary">
+                <div v-if="course.nonstandardMeetingDates">
                   <span class="text-no-wrap">{{ meetings(course)[index].startDate | moment('MMM D, YYYY') }} - </span>
                   <span class="text-no-wrap">{{ meetings(course)[index].endDate | moment('MMM D, YYYY') }}</span>
                 </div>
-                <div :class="{'pb-2': course.meetingDateRangesVary && index === meetings(course).length - 1}">
+                <div :class="{'pb-2': course.nonstandardMeetingDates && index === meetings(course).length - 1}">
                   {{ meetings(course)[index].startTimeFormatted }} - {{ meetings(course)[index].endTimeFormatted }}
                 </div>
               </td>

--- a/src/views/CourseChanges.vue
+++ b/src/views/CourseChanges.vue
@@ -49,8 +49,8 @@
               <div>
                 {{ course.sectionId }}
               </div>
-              <div v-if="course.scheduled.hasObsoleteMeetingTimes">
-                <div :id="`course-${course.sectionId}-meeting-before`">
+              <div v-if="course.scheduled.hasObsoleteMeetingTimes" :id="`course-${course.sectionId}-obsolete-meeting-times`">
+                <div :id="`course-${course.sectionId}-meeting-times-old`">
                   {{ course.scheduled.meetingDays.join(',') }} {{ course.scheduled.meetingStartTime }} - {{ course.scheduled.meetingEndTime }}
                 </div>
                 <div class="primary--text">
@@ -58,11 +58,26 @@
                   changed to
                 </div>
               </div>
-              <div v-for="(meeting, index) in course.meetings.eligible" :id="`course-${course.sectionId}-meeting-new-eligible-${index}`" :key="index">
+              <div v-for="(meeting, index) in course.meetings.eligible" :id="`course-${course.sectionId}-meeting-times-eligible-${index}`" :key="index">
                 {{ meeting.daysFormatted.join(',') }} {{ meeting.startTimeFormatted }} - {{ meeting.endTimeFormatted }} (Eligible)
               </div>
-              <div v-for="(meeting, index) in course.meetings.ineligible" :id="`course-${course.sectionId}-meeting-new-ineligible-${index}`" :key="index">
+              <div v-for="(meeting, index) in course.meetings.ineligible" :id="`course-${course.sectionId}-meeting-times-ineligible-${index}`" :key="index">
                 {{ meeting.daysFormatted.join(',') }} {{ meeting.startTimeFormatted }} - {{ meeting.endTimeFormatted }} (Ineligible)
+              </div>
+              <div v-if="course.scheduled.hasObsoleteMeetingDates" :id="`course-${course.sectionId}-obsolete-meeting-dates`">
+                <div :id="`course-${course.sectionId}-meeting-dates-old`">
+                  {{ course.scheduled.meetingStartDate }} - {{ course.scheduled.meetingEndDate }}
+                </div>
+                <div class="primary--text">
+                  <v-icon small color="primary">mdi-arrow-down-bold</v-icon>
+                  changed to
+                </div>
+                <div v-for="(meeting, index) in course.meetings.eligible" :id="`course-${course.sectionId}-meeting-dates-eligible-${index}`" :key="index">
+                  {{ meeting.startDate }} - {{ meeting.endDate }} (Eligible)
+                </div>
+                <div v-for="(meeting, index) in course.meetings.ineligible" :id="`course-${course.sectionId}-meeting-dates-ineligible-${index}`" :key="index">
+                  {{ meeting.startDate }} - {{ meeting.endDate }} (Ineligible)
+                </div>
               </div>
               <div>
                 {{ course.publishTypeNames }}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -40,7 +40,7 @@
                 {{ $_.join(course.meetings.eligible[0].daysFormatted, ', ') }}
               </td>
               <td :class="{'border-bottom-zero': course.meetings.eligible.length > 1}" class="text-no-wrap">
-                <div v-if="course.meetingDateRangesVary" class="pt-2">
+                <div v-if="course.nonstandardMeetingDates" class="pt-2">
                   <span class="text-no-wrap">{{ course.meetings.eligible[0].startDate | moment('MMM D, YYYY') }} - </span>
                   <span class="text-no-wrap">{{ course.meetings.eligible[0].endDate | moment('MMM D, YYYY') }}</span>
                 </div>
@@ -58,11 +58,11 @@
                 {{ $_.join(course.meetings.eligible[index].daysFormatted, ', ') }}
               </td>
               <td class="text-no-wrap">
-                <div v-if="course.meetingDateRangesVary" class="pt-2">
+                <div v-if="course.nonstandardMeetingDates" class="pt-2">
                   <span class="text-no-wrap">{{ course.meetings.eligible[index].startDate | moment('MMM D, YYYY') }} - </span>
                   <span class="text-no-wrap">{{ course.meetings.eligible[index].endDate | moment('MMM D, YYYY') }}</span>
                 </div>
-                <div :class="{'pb-2': course.meetingDateRangesVary && index === course.meetings.eligible.length - 1}">
+                <div :class="{'pb-2': course.nonstandardMeetingDates && index === course.meetings.eligible.length - 1}">
                   {{ course.meetings.eligible[index].startTimeFormatted }} - {{ course.meetings.eligible[index].endTimeFormatted }}
                 </div>
               </td>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-444

For now we compare date values as strings; this will change with https://jira.ets.berkeley.edu/jira/browse/DIABLO-456.

We also switch the course API feed over from highlighting `meetingDateRangesVary` to `nonstandardMeetingDates`.