### PR TITLE
DIABLO-456, meeting dates in sis_sections and scheduled are now timestamps

### DIFF
--- a/diablo/jobs/util.py
+++ b/diablo/jobs/util.py
@@ -95,10 +95,10 @@ def refresh_cross_listings(term_id):
                 FROM sis_sections
                 WHERE term_id = :term_id
                     AND meeting_days <> ''
-                    AND meeting_end_date <> ''
+                    AND meeting_end_date IS NOT NULL
                     AND meeting_end_time <> ''
                     AND meeting_location <> ''
-                    AND meeting_start_date <> ''
+                    AND meeting_start_date IS NOT NULL
                     AND meeting_start_time <> ''
                 ORDER BY schedule, section_id
             """
@@ -190,9 +190,9 @@ def schedule_recordings(all_approvals, course):
                 instructor_uids=[i['uid'] for i in course['instructors']],
                 kaltura_schedule_id=kaltura_schedule_id,
                 meeting_days=meeting['days'],
-                meeting_end_date=get_recording_end_date(meeting).strftime('%Y-%m-%d'),
+                meeting_end_date=get_recording_end_date(meeting),
                 meeting_end_time=meeting['endTime'],
-                meeting_start_date=get_recording_start_date(meeting).strftime('%Y-%m-%d'),
+                meeting_start_date=get_recording_start_date(meeting),
                 meeting_start_time=meeting['startTime'],
                 publish_type_=approval.publish_type,
                 recording_type_=approval.recording_type,

--- a/diablo/models/development_db.py
+++ b/diablo/models/development_db.py
@@ -99,16 +99,32 @@ def _load_courses():
 
 def _create_email_templates():
     EmailTemplate.create(
+        template_type='admin_alert_date_change',
+        name='Scheduled course had date change',
+        subject_line='Funky dates!',
+        message="""
+            Scheduled recordings of <code>course.name</code> have invalid dates:
+            <code>course.date.start</code> to <code>course.date.end</code>.
+        """,
+    )
+    EmailTemplate.create(
         template_type='admin_alert_instructor_change',
         name='Alert admin instructors change',
         subject_line='Instructors have changed',
-        message='<code>course.name</code>: old instructor(s) <code>instructors.previous</code>, new instructor(s) <code>instructors.all</code>.',
+        message="""
+            <code>course.name</code>:
+            Old instructor(s) <code>instructors.previous</code>
+            New instructor(s) <code>instructors.all</code>
+        """,
     )
     EmailTemplate.create(
         template_type='admin_alert_multiple_meeting_patterns',
         name='Alert admin when multiple meeting patterns',
         subject_line="It's complicated!",
-        message='<code>course.name</code> has weird dates: <code>course.date.start</code> to <code>course.date.end</code>',
+        message="""
+            <code>course.name</code> has weird dates:
+            <code>course.date.start</code> to <code>course.date.end</code>
+        """,
     )
     EmailTemplate.create(
         template_type='admin_alert_room_change',

--- a/diablo/models/scheduled.py
+++ b/diablo/models/scheduled.py
@@ -41,9 +41,9 @@ class Scheduled(db.Model):
     instructor_uids = db.Column(ARRAY(db.String(80)), nullable=False)
     kaltura_schedule_id = db.Column(db.Integer, nullable=False)
     meeting_days = db.Column(db.String, nullable=False)
-    meeting_end_date = db.Column(db.String, nullable=False)
+    meeting_end_date = db.Column(db.DateTime, nullable=False)
     meeting_end_time = db.Column(db.String, nullable=False)
-    meeting_start_date = db.Column(db.String, nullable=False)
+    meeting_start_date = db.Column(db.DateTime, nullable=False)
     meeting_start_time = db.Column(db.String, nullable=False)
     publish_type = db.Column(publish_type, nullable=False)
     recording_type = db.Column(recording_type, nullable=False)
@@ -162,9 +162,9 @@ class Scheduled(db.Model):
             'instructorUids': self.instructor_uids,
             'kalturaScheduleId': self.kaltura_schedule_id,
             'meetingDays': format_days(self.meeting_days),
-            'meetingEndDate': self.meeting_end_date,
+            'meetingEndDate': datetime.strftime(self.meeting_end_date, '%Y-%m-%d'),
             'meetingEndTime': format_time(self.meeting_end_time),
-            'meetingStartDate': self.meeting_start_date,
+            'meetingStartDate': datetime.strftime(self.meeting_start_date, '%Y-%m-%d'),
             'meetingStartTime': format_time(self.meeting_start_time),
             'publishType': self.publish_type,
             'publishTypeName': NAMES_PER_PUBLISH_TYPE[self.publish_type],

--- a/diablo/sql_templates/update_rds_sis_sections.template.sql
+++ b/diablo/sql_templates/update_rds_sis_sections.template.sql
@@ -34,8 +34,8 @@ INSERT INTO sis_sections (allowed_units, course_name, course_title, instruction_
    (SELECT * FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
     SELECT
        allowed_units, course_display_name, course_title, instruction_format, instructor_name, instructor_role_code,
-       instructor_uid, is_primary::BOOLEAN, meeting_days, meeting_end_date, meeting_end_time, meeting_location,
-       meeting_start_date, meeting_start_time, section_id::INTEGER, section_num, term_id::INTEGER
+       instructor_uid, is_primary::BOOLEAN, meeting_days, meeting_end_date::TIMESTAMP, meeting_end_time, meeting_location,
+       meeting_start_date::TIMESTAMP, meeting_start_time, section_id::INTEGER, section_num, term_id::INTEGER
     FROM {redshift_schema_sis}.courses
     WHERE term_id='{term_id}'
   $REDSHIFT$)
@@ -49,10 +49,10 @@ INSERT INTO sis_sections (allowed_units, course_name, course_title, instruction_
     instructor_uid VARCHAR(80),
     is_primary BOOLEAN,
     meeting_days VARCHAR(80),
-    meeting_end_date VARCHAR(80),
+    meeting_end_date TIMESTAMP,
     meeting_end_time VARCHAR(80),
     meeting_location VARCHAR(80),
-    meeting_start_date VARCHAR(80),
+    meeting_start_date TIMESTAMP,
     meeting_start_time VARCHAR(80),
     section_id INTEGER,
     section_num VARCHAR(80),

--- a/scripts/db/migrate/2020/20200624-DIABLO-456/column_type_timestamp_for_meeting_dates.sql
+++ b/scripts/db/migrate/2020/20200624-DIABLO-456/column_type_timestamp_for_meeting_dates.sql
@@ -1,0 +1,34 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+ALTER TABLE scheduled ALTER COLUMN meeting_end_date TYPE TIMESTAMP USING meeting_end_date::TIMESTAMP;
+ALTER TABLE scheduled ALTER COLUMN meeting_start_date TYPE TIMESTAMP USING meeting_start_date::TIMESTAMP;
+
+ALTER TABLE sis_sections ALTER COLUMN meeting_end_date TYPE TIMESTAMP USING meeting_end_date::TIMESTAMP;
+ALTER TABLE sis_sections ALTER COLUMN meeting_start_date TYPE TIMESTAMP USING meeting_start_date::TIMESTAMP;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -92,9 +92,9 @@ CREATE TYPE room_capability_types AS ENUM (
 CREATE TABLE admin_users (
     id integer NOT NULL,
     uid character varying(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
-    deleted_at timestamp with time zone
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE
 );
 ALTER TABLE admin_users OWNER TO diablo;
 CREATE SEQUENCE admin_users_id_seq
@@ -122,8 +122,8 @@ CREATE TABLE approvals (
     publish_type publish_types NOT NULL,
     recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    deleted_at timestamp with time zone
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE
 );
 ALTER TABLE approvals OWNER TO diablo;
 CREATE UNIQUE INDEX approvals_unique_idx ON approvals (approved_by_uid, section_id, term_id) WHERE deleted_at IS NULL;
@@ -135,7 +135,7 @@ CREATE TABLE canvas_course_sites (
     section_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
     canvas_course_site_name TEXT NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE canvas_course_sites OWNER TO diablo;
 ALTER TABLE canvas_course_sites ADD CONSTRAINT canvas_course_sites_pkey PRIMARY KEY (canvas_course_site_id, section_id, term_id);
@@ -146,7 +146,7 @@ CREATE TABLE course_preferences (
     term_id INTEGER NOT NULL,
     section_id INTEGER NOT NULL,
     has_opted_out BOOLEAN NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE course_preferences OWNER TO diablo;
 ALTER TABLE course_preferences ADD CONSTRAINT course_preferences_pkey PRIMARY KEY (section_id, term_id);
@@ -157,7 +157,7 @@ CREATE TABLE cross_listings (
     term_id INTEGER NOT NULL,
     section_id INTEGER NOT NULL,
     cross_listed_section_ids INTEGER[] NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE cross_listings OWNER TO diablo;
 ALTER TABLE cross_listings ADD CONSTRAINT cross_listings_pkey PRIMARY KEY (section_id, term_id);
@@ -170,8 +170,8 @@ CREATE TABLE email_templates (
     name VARCHAR(255) NOT NULL,
     message TEXT NOT NULL,
     subject_line VARCHAR(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE email_templates OWNER TO diablo;
 CREATE SEQUENCE email_templates_id_seq
@@ -196,8 +196,8 @@ CREATE TABLE instructors (
     email VARCHAR(255),
     first_name VARCHAR(255),
     last_name VARCHAR(255),
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE instructors OWNER TO diablo;
 ALTER TABLE ONLY instructors
@@ -209,8 +209,8 @@ CREATE TABLE job_history (
     id INTEGER NOT NULL,
     job_key VARCHAR(80) NOT NULL,
     failed BOOLEAN DEFAULT FALSE,
-    started_at timestamp with time zone NOT NULL,
-    finished_at timestamp with time zone
+    started_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    finished_at TIMESTAMP WITH TIME ZONE
 );
 ALTER TABLE job_history OWNER TO diablo;
 CREATE SEQUENCE job_history_id_seq
@@ -233,8 +233,8 @@ CREATE TABLE jobs (
     job_schedule_type job_schedule_types NOT NULL,
     job_schedule_value VARCHAR(80) NOT NULL,
     key VARCHAR(80) NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    updated_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE jobs OWNER TO diablo;
 CREATE SEQUENCE jobs_id_seq
@@ -261,7 +261,7 @@ CREATE TABLE queued_emails (
     section_id INTEGER NOT NULL,
     template_type email_template_types,
     term_id INTEGER NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE queued_emails OWNER TO diablo;
 CREATE SEQUENCE queued_emails_id_seq
@@ -284,7 +284,7 @@ CREATE TABLE rooms (
     is_auditorium BOOLEAN NOT NULL,
     kaltura_resource_id INTEGER,
     location VARCHAR(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE rooms OWNER TO diablo;
 CREATE SEQUENCE rooms_id_seq
@@ -311,15 +311,15 @@ CREATE TABLE scheduled (
     instructor_uids VARCHAR(80)[] NOT NULL,
     kaltura_schedule_id INTEGER NOT NULL,
     meeting_days VARCHAR(80) NOT NULL,
-    meeting_end_date VARCHAR(80) NOT NULL,
+    meeting_end_date TIMESTAMP NOT NULL,
     meeting_end_time VARCHAR(80) NOT NULL,
-    meeting_start_date VARCHAR(80) NOT NULL,
+    meeting_start_date TIMESTAMP NOT NULL,
     meeting_start_time VARCHAR(80) NOT NULL,
     publish_type publish_types NOT NULL,
     recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,
-    created_at timestamp with time zone NOT NULL,
-    deleted_at timestamp with time zone
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE
 );
 ALTER TABLE scheduled OWNER TO diablo;
 CREATE UNIQUE INDEX scheduled_unique_idx ON scheduled (section_id, term_id) WHERE deleted_at IS NULL;
@@ -332,7 +332,7 @@ CREATE TABLE sent_emails (
     section_id INTEGER,
     template_type email_template_types,
     term_id INTEGER NOT NULL,
-    sent_at timestamp with time zone NOT NULL
+    sent_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE sent_emails OWNER TO diablo;
 CREATE SEQUENCE sent_emails_id_seq
@@ -362,15 +362,15 @@ CREATE TABLE sis_sections (
     is_primary BOOLEAN,
     is_principal_listing BOOLEAN DEFAULT TRUE NOT NULL,
     meeting_days VARCHAR(80),
-    meeting_end_date VARCHAR(80),
+    meeting_end_date TIMESTAMP,
     meeting_end_time VARCHAR(80),
     meeting_location VARCHAR(80),
-    meeting_start_date VARCHAR(80),
+    meeting_start_date TIMESTAMP,
     meeting_start_time VARCHAR(80),
     section_id INTEGER NOT NULL,
     section_num VARCHAR(80),
     term_id INTEGER NOT NULL,
-    created_at timestamp with time zone NOT NULL
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 ALTER TABLE sis_sections OWNER TO diablo;
 CREATE SEQUENCE sis_sections_id_seq

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -30,6 +30,7 @@ import random
 from diablo import std_commit
 from diablo.jobs.canvas_job import CanvasJob
 from diablo.jobs.queued_emails_job import QueuedEmailsJob
+from diablo.lib.berkeley import get_recording_end_date, get_recording_start_date
 from diablo.models.approval import Approval
 from diablo.models.course_preference import CoursePreference
 from diablo.models.room import Room
@@ -736,9 +737,9 @@ class TestCoursesChanges:
                 instructor_uids=get_instructor_uids(term_id=self.term_id, section_id=section_1_id),
                 kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=obsolete_meeting_days,
-                meeting_end_date=meeting['endDate'],
+                meeting_end_date=get_recording_end_date(meeting),
                 meeting_end_time=meeting['endTime'],
-                meeting_start_date=meeting['startDate'],
+                meeting_start_date=get_recording_start_date(meeting),
                 meeting_start_time=meeting['startTime'],
                 publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
@@ -796,9 +797,9 @@ class TestCoursesChanges:
                 instructor_uids=instructor_uids + ['100099'],
                 kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting['days'],
-                meeting_end_date=meeting['endDate'],
+                meeting_end_date=get_recording_end_date(meeting),
                 meeting_end_time=meeting['endTime'],
-                meeting_start_date=meeting['startDate'],
+                meeting_start_date=get_recording_start_date(meeting),
                 meeting_start_time=meeting['startTime'],
                 publish_type_='kaltura_my_media',
                 recording_type_='presenter_audio',
@@ -1097,9 +1098,9 @@ def _schedule_recordings(
         instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
         kaltura_schedule_id=random.randint(1, 10),
         meeting_days=meeting['days'],
-        meeting_end_date=meeting['endDate'],
+        meeting_end_date=get_recording_end_date(meeting),
         meeting_end_time=meeting['endTime'],
-        meeting_start_date=meeting['startDate'],
+        meeting_start_date=get_recording_start_date(meeting),
         meeting_start_time=meeting['startTime'],
         publish_type_=publish_type,
         recording_type_=recording_type,

--- a/tests/util.py
+++ b/tests/util.py
@@ -52,6 +52,7 @@ def test_approvals_workflow(app):
         db.session.execute(text('DELETE FROM approvals'))
         db.session.execute(text('DELETE FROM course_preferences'))
         db.session.execute(text('DELETE FROM scheduled'))
+        db.session.execute(text('DELETE FROM queued_emails'))
         db.session.execute(text('DELETE FROM sent_emails'))
 
     try:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-456

The db/migrate scripts worked locally, with non-empty tables. I have not tested with type casting in `update_rds_sis_sections.template.sql`.
