### PR TITLE
DIABLO-464, recording_start/end calculated with course.meeting.days in mind

### DIFF
--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -27,9 +27,9 @@ import json
 
 import dateutil.parser
 from diablo import cachify, skip_when_pytest
-from diablo.lib.berkeley import get_recording_end_date, get_recording_start_date, term_name_for_sis_id
-from diablo.lib.kaltura_util import get_classification_name, get_first_matching_datetime_of_term, get_recurrence_name, \
-    get_status_name
+from diablo.lib.berkeley import get_first_matching_datetime_of_term, get_recording_end_date, get_recording_start_date, \
+    term_name_for_sis_id
+from diablo.lib.kaltura_util import get_classification_name, get_recurrence_name, get_status_name
 from diablo.lib.util import default_timezone, epoch_time_to_isoformat, format_days, to_isoformat
 from flask import current_app as app
 from KalturaClient import KalturaClient, KalturaConfiguration

--- a/diablo/lib/kaltura_util.py
+++ b/diablo/lib/kaltura_util.py
@@ -22,14 +22,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
-from datetime import datetime, timedelta
-
-from diablo.lib.util import default_timezone
 from KalturaClient.Plugins.Schedule import KalturaScheduleEventClassificationType, KalturaScheduleEventRecurrenceType, \
     KalturaScheduleEventStatus
-
-# This order of days is aligned with datetime module: https://pythontic.com/datetime/date/weekday
-DAYS = ('MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU')
 
 
 def get_classification_name(classification_type):
@@ -46,27 +40,6 @@ def get_recurrence_name(recurrence_type):
         KalturaScheduleEventRecurrenceType.RECURRENCE: 'Recurrence',
         KalturaScheduleEventRecurrenceType.RECURRING: 'Recurring',
     }[recurrence_type.value]
-
-
-def get_first_matching_datetime_of_term(meeting_days, start_date, time_hours, time_minutes):
-    first_meeting = None
-    meeting_day_indices = [DAYS.index(day) for day in meeting_days]
-    for index in range(7):
-        # Monday is 0 and Sunday is 6
-        day_index = (start_date.weekday() + index) % 7
-        if day_index in meeting_day_indices:
-            first_day = start_date + timedelta(days=index)
-            first_meeting = default_timezone().localize(
-                datetime(
-                    first_day.year,
-                    first_day.month,
-                    first_day.day,
-                    time_hours,
-                    time_minutes,
-                ),
-            )
-            break
-    return first_meeting
 
 
 def get_status_name(status_type):

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -407,6 +407,7 @@ class TestGetCourse:
         assert api_json['meetingType'] == 'B'
 
     def test_meeting_recording_end_date(self, client, admin_session):
+        # The term ends on a Tuesday
         with override_config(app, 'CURRENT_TERM_END', '2020-11-24'):
             api_json = api_get_course(
                 client,
@@ -414,7 +415,8 @@ class TestGetCourse:
                 section_id=50015,
             )
             assert api_json['meetings']['eligible'][0]['endDate'] == '2020-12-11'
-            assert api_json['meetings']['eligible'][0]['recordingEndDate'] == '2020-11-24'
+            # The course meets on ['MO', 'WE', 'FR']. The last recordings is on Wed preceding term_end
+            assert api_json['meetings']['eligible'][0]['recordingEndDate'] == '2020-11-23'
             assert api_json['meetings']['ineligible'][0]['endDate'] == '2020-12-11'
             assert 'recordingEndDate' not in api_json['meetings']['ineligible'][0]
 

--- a/tests/test_lib/test_kaltura_util.py
+++ b/tests/test_lib/test_kaltura_util.py
@@ -22,77 +22,30 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
-from datetime import datetime
-
-from diablo.lib.kaltura_util import get_first_matching_datetime_of_term
-from flask import current_app as app
-import pytz
-from tests.util import override_config
+from diablo.lib.kaltura_util import get_classification_name, get_recurrence_name, get_status_name
+from KalturaClient.Plugins.Schedule import KalturaScheduleEventClassificationType, KalturaScheduleEventRecurrenceType, \
+    KalturaScheduleEventStatus
 
 
-class TestFirstDayRecording:
+class TestKalturaEnums:
 
-    def test_first_meeting_is_same_as_term_begin(self):
-        """First meeting of course is the same day as first of term."""
-        with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
-            first_day_start = get_first_matching_datetime_of_term(
-                meeting_days=['MO', 'WE', 'FR'],
-                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
-                time_hours=13,
-                time_minutes=30,
-            )
-            assert first_day_start.day == 26
+    def test_classification_name(self):
+        """Friendly name for KalturaScheduleEventClassificationType enum values."""
+        assert get_classification_name(None) is None
+        assert get_classification_name(
+            KalturaScheduleEventClassificationType(KalturaScheduleEventClassificationType.PUBLIC_EVENT),
+        ) == 'Public'
 
-    def test_first_meeting_is_day_after_term_begin(self):
-        """First meeting is the day after start of term."""
-        with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
-            first_day_start = get_first_matching_datetime_of_term(
-                meeting_days=['TU', 'TH'],
-                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
-                time_hours=13,
-                time_minutes=30,
-            )
-            assert first_day_start.day == 27
+    def test_recurrence_name(self):
+        """Friendly name for KalturaScheduleEventRecurrenceType enum values."""
+        assert get_recurrence_name(None) is None
+        assert get_recurrence_name(
+            KalturaScheduleEventRecurrenceType(KalturaScheduleEventRecurrenceType.RECURRING),
+        ) == 'Recurring'
 
-    def test_first_meeting_is_week_after_term_begin(self):
-        """First meeting is the Monday following first week of term."""
-        with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
-            first_day_start = get_first_matching_datetime_of_term(
-                meeting_days=['MO', 'TU'],
-                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
-                time_hours=8,
-                time_minutes=45,
-            )
-            assert first_day_start.day == 31
-
-    def test_first_meeting_is_different_month(self):
-        """First meeting is in week after start of term, in a new month."""
-        with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
-            first_day_start = get_first_matching_datetime_of_term(
-                meeting_days=['TU'],
-                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
-                time_hours=9,
-                time_minutes=15,
-            )
-            assert first_day_start.month == 9
-            assert first_day_start.day == 1
-
-    def test_timestamps(self):
-        """Epoch timestamp in PST timezone."""
-        with override_config(app, 'CURRENT_TERM_BEGIN', _get_wednesday_august_26()):
-            first_day_start = get_first_matching_datetime_of_term(
-                meeting_days=['TU', 'TH'],
-                start_date=datetime.strptime(app.config['CURRENT_TERM_BEGIN'], '%Y-%m-%d'),
-                time_hours=9,
-                time_minutes=37,
-            )
-            assert first_day_start.timestamp() == 1598546220.0
-
-
-def _get_wednesday_august_26():
-    # Aug 26, 2020, is a Wednesday.
-    return '2020-08-26'
-
-
-def _timezone():
-    return pytz.timezone(app.config['TIMEZONE'])
+    def test_status_name(self):
+        """Friendly name for KalturaScheduleEventStatus enum values."""
+        assert get_status_name(None) is None
+        assert get_status_name(
+            KalturaScheduleEventStatus(KalturaScheduleEventStatus.ACTIVE),
+        ) == 'Active'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-464

Recording-end-date config '2020-11-24' is a Tuesday and the course meets ['MO','WE','FR'], thus we expect '2020-11-23' from `get_recording_end_date(meeting)`