### PR TITLE
DIABLO-490, admin_alert is sent again if the 'scheduled' record is new

### DIFF
--- a/scripts/db/migrate/2020/20200703-DIABLO-490/alter_scheduled_table_add_alerts.sql
+++ b/scripts/db/migrate/2020/20200703-DIABLO-490/alter_scheduled_table_add_alerts.sql
@@ -1,0 +1,30 @@
+/**
+ * Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+ALTER TABLE scheduled ADD COLUMN alerts email_template_types[];
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -314,6 +314,7 @@ CREATE TABLE scheduled (
     id SERIAL PRIMARY KEY,
     section_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
+    alerts email_template_types[],
     instructor_uids VARCHAR(80)[] NOT NULL,
     kaltura_schedule_id INTEGER NOT NULL,
     meeting_days VARCHAR(80) NOT NULL,

--- a/src/components/course/ScheduledCourse.vue
+++ b/src/components/course/ScheduledCourse.vue
@@ -29,6 +29,16 @@
         <v-list-item-subtitle>{{ course.scheduled.publishTypeName }}</v-list-item-subtitle>
       </v-list-item-content>
     </v-list-item>
+    <v-list-item v-if="$currentUser.isAdmin && course.scheduled.alerts.length" two-line class="pb-3">
+      <v-list-item-content>
+        <v-list-item-title>
+          <v-icon class="pb-1 pr-1" color="red">mdi-alert</v-icon>
+          <OxfordJoin v-slot="{ item }" :items="course.scheduled.alerts">
+            {{ $config.emailTemplateTypes[item] }}
+          </OxfordJoin>
+        </v-list-item-title>
+      </v-list-item-content>
+    </v-list-item>
     <v-card-text v-if="currentUserMustApprove">
       <v-container>
         <v-row class="pb-2">
@@ -70,12 +80,13 @@
 
 <script>
   import Context from '@/mixins/Context'
+  import OxfordJoin from '@/components/util/OxfordJoin'
   import TermsAgreementText from '@/components/util/TermsAgreementText'
   import {approve} from '@/api/course'
 
   export default {
     name: 'ScheduledCourse',
-    components: {TermsAgreementText},
+    components: {OxfordJoin, TermsAgreementText},
     mixins: [Context],
     props: {
       afterApprove: {

--- a/tests/test_api/api_test_utils.py
+++ b/tests/test_api/api_test_utils.py
@@ -23,9 +23,14 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 import json
+import random
 
-from diablo import cachify
+from diablo import cachify, db, std_commit
+from diablo.lib.berkeley import get_recording_end_date, get_recording_start_date
+from diablo.models.room import Room
+from diablo.models.scheduled import Scheduled
 from diablo.models.sis_section import SisSection
+from sqlalchemy import text
 
 
 def api_approve(
@@ -71,3 +76,50 @@ def get_eligible_meeting(section_id, term_id):
 def get_instructor_uids(section_id, term_id):
     course = SisSection.get_course(section_id=section_id, term_id=term_id)
     return [instructor['uid'] for instructor in course['instructors']]
+
+
+def mock_scheduled(
+        meeting,
+        section_id,
+        term_id,
+        override_end_date=None,
+        override_end_time=None,
+        override_start_date=None,
+        override_start_time=None,
+):
+    scheduled = Scheduled.create(
+        instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
+        kaltura_schedule_id=random.randint(1, 10),
+        meeting_days='MO,WE,FR',
+        meeting_end_date=override_end_date or get_recording_end_date(meeting),
+        meeting_end_time=override_end_time or meeting['endTime'],
+        meeting_start_date=override_start_date or get_recording_start_date(meeting, return_today_if_past_start=True),
+        meeting_start_time=override_start_time or meeting['startTime'],
+        publish_type_='kaltura_media_gallery',
+        recording_type_='presenter_presentation_audio',
+        room_id=Room.get_room_id(section_id=section_id, term_id=term_id),
+        section_id=section_id,
+        term_id=term_id,
+    )
+    if override_end_date or override_end_time or override_start_date or override_start_time:
+        args = {
+            'meeting_end_date': override_end_date,
+            'meeting_end_time': override_end_time,
+            'meeting_start_date': override_start_date,
+            'meeting_start_time': override_start_time,
+        }
+        sql = 'UPDATE scheduled SET'
+        previous_value = None
+        for key, value in args.items():
+            if value:
+                sql += f"{',' if previous_value else ''} {key} = :{key}"
+                previous_value = value
+        sql += ' WHERE id = :id'
+        db.session.execute(
+            text(sql),
+            {
+                **{'id': scheduled.id},
+                **args,
+            },
+        )
+    std_commit(allow_test_environment=True)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-490

Add column `alerts`, an array of email_template_types, to the `scheduled` table.

When a bogus schedule is unscheduled, emails to admin will be sent again if the course suffers more change in dates/times, rooms, etc.