### PR TITLE
DIABLO-502, EMAIL_SYSTEM_ERRORS can be addresses (list) or address (string)

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -80,8 +80,8 @@ EMAIL_COURSE_CAPTURE_SUPPORT = '__EMAIL_COURSE_CAPTURE_SUPPORT__at_berkeley.edu'
 EMAIL_COURSE_CAPTURE_SUPPORT_LABEL = 'Course Capture Admin'
 EMAIL_DIABLO_ADMIN = '__EMAIL_DIABLO_ADMIN__at_berkeley.edu'
 EMAIL_DIABLO_ADMIN_UID = '0'
-EMAIL_REDIRECT_WHEN_TESTING = '__EMAIL_REDIRECT_WHEN_TESTING__at_berkeley.edu'
-EMAIL_SYSTEM_ERRORS = '__EMAIL_SYSTEM_ERRORS__at_berkeley.edu'
+EMAIL_REDIRECT_WHEN_TESTING = ['__EMAIL_REDIRECT_WHEN_TESTING__at_berkeley.edu']
+EMAIL_SYSTEM_ERRORS = ['__EMAIL_SYSTEM_ERRORS__at_berkeley.edu']
 EMAIL_TEST_MODE = True
 
 # Useful when working on or debugging the Kaltura integration. Recommended for localhost only.

--- a/diablo/merged/emailer.py
+++ b/diablo/merged/emailer.py
@@ -37,13 +37,16 @@ def get_admin_alert_recipient():
 def send_system_error_email(message, subject=None):
     if subject is None:
         subject = f'{message[:50]}...' if len(message) > 50 else message
-    BConnected().send(
-        message=message,
-        recipient={
-            'email': app.config['EMAIL_SYSTEM_ERRORS'],
-            'name': 'Course Capture Errors',
-            'uid': '0',
-        },
-        subject_line=f'Alert: {subject}',
-    )
+    config_value = app.config['EMAIL_SYSTEM_ERRORS']
+    email_addresses = config_value if isinstance(config_value, list) else [config_value]
+    for email_address in email_addresses:
+        BConnected().send(
+            message=message,
+            recipient={
+                'email': email_address,
+                'name': 'Course Capture Errors',
+                'uid': '0',
+            },
+            subject_line=f'Alert: {subject}',
+        )
     app.logger.error(f'Alert: {message}')

--- a/tests/test_jobs/test_admin_emails_job.py
+++ b/tests/test_jobs/test_admin_emails_job.py
@@ -51,7 +51,7 @@ def enable_admin_emails():
     std_commit(allow_test_environment=True)
 
 
-class TestEmailAlertsForAdmins:
+class TestAdminEmailsJob:
 
     def test_admin_alert_date_change(self, db_session, enable_admin_emails):
         admin_uid = app.config['EMAIL_DIABLO_ADMIN_UID']

--- a/tests/test_jobs/test_instructor_emails_job.py
+++ b/tests/test_jobs/test_instructor_emails_job.py
@@ -44,7 +44,7 @@ def enable_instructor_emails_job():
     std_commit(allow_test_environment=True)
 
 
-class TestEmailAlertsForAdmins:
+class TestInstructorEmailsJob:
 
     def test_room_change_no_longer_eligible(self, db_session, enable_instructor_emails_job):
         term_id = app.config['CURRENT_TERM_ID']

--- a/tests/test_lib/test_interpolator.py
+++ b/tests/test_lib/test_interpolator.py
@@ -49,12 +49,18 @@ class TestInterpolator:
     def test_email_test_mode_on(self):
         with override_config(app, 'EMAIL_TEST_MODE', True):
             recipient = _get_mock_recipient()
-            assert BConnected.get_email_address(recipient) == app.config['EMAIL_REDIRECT_WHEN_TESTING']
+            test_email_address = 'foo@berkeley.edu'
+            # EMAIL_REDIRECT_WHEN_TESTING can be single email address (string) or list of addresses.
+            expected = [test_email_address]
+            with override_config(app, 'EMAIL_REDIRECT_WHEN_TESTING', test_email_address):
+                assert BConnected.get_email_addresses(recipient) == expected
+            with override_config(app, 'EMAIL_REDIRECT_WHEN_TESTING', [test_email_address]):
+                assert BConnected.get_email_addresses(recipient) == expected
 
     def test_email_test_mode_off(self):
         with override_config(app, 'EMAIL_TEST_MODE', False):
             recipient = _get_mock_recipient()
-            assert BConnected.get_email_address(recipient) == recipient['email']
+            assert BConnected.get_email_addresses(recipient) == [recipient['email']]
 
 
 def _get_mock_recipient():


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-502

IMO, better than managing custom email list. Review with `?w=1`