### PR TITLE
DIABLO-510, logic of get_courses_ready_to_schedule() is now shared

### DIFF
--- a/diablo/externals/b_connected.py
+++ b/diablo/externals/b_connected.py
@@ -59,7 +59,6 @@ class BConnected:
 
         @skip_when_pytest()
         def _send():
-            # Connect to SMTP server
             smtp = SMTP(self.bcop_smtp_server, port=self.bcop_smtp_port)
             # TLS encryption
             smtp.starttls()
@@ -68,14 +67,8 @@ class BConnected:
 
             emails_sent_to = set()
 
-            mock_message = _get_mock_message(
-                recipient['name'],
-                recipient['email'],
-                subject_line,
-                message,
-            )
             if app.config['DIABLO_ENV'] == 'test':
-                app.logger.info(mock_message)
+                write_email_to_log(message=message, recipient=recipient, subject_line=subject_line)
             else:
                 from_address = f"{app.config['EMAIL_COURSE_CAPTURE_SUPPORT_LABEL']} <{app.config['EMAIL_COURSE_CAPTURE_SUPPORT']}>"
 
@@ -128,10 +121,10 @@ class BConnected:
             return [user['email']]
 
 
-def _get_mock_message(recipient_name, email_address, subject_line, message):
-    return f"""
+def write_email_to_log(message, recipient, subject_line):
+    app.logger.info(f"""
 
-        To: {recipient_name} <{email_address}>
+        To: {recipient['name']} <{recipient['email']}>
         Cc: Course Capture Admin <{app.config['EMAIL_DIABLO_ADMIN']}>
         From: {app.config['EMAIL_COURSE_CAPTURE_SUPPORT_LABEL']} <{app.config['EMAIL_COURSE_CAPTURE_SUPPORT']}>
         Subject: {subject_line}
@@ -139,4 +132,4 @@ def _get_mock_message(recipient_name, email_address, subject_line, message):
         Message:
         {message}
 
-    """
+    """)

--- a/diablo/jobs/background_job_manager.py
+++ b/diablo/jobs/background_job_manager.py
@@ -49,8 +49,8 @@ class BackgroundJobManager:
         """Continuously run, executing pending jobs per time interval.
 
         It is intended behavior that ScheduleThread does not run missed jobs. For example, if you register a job that
-        should run every minute and yet SCHEDULER_INTERVAL is set to one hour, then your job won't run 60 times at
-        each interval. It will run once.
+        should run every minute and yet JOBS_SECONDS_BETWEEN_PENDING_CHECK is set to one hour, then your job won't run
+        60 times at each interval. It will run once.
         """
         if self.is_running():
             return


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-510

A little cleanup here. We want `/api/course/approve` to use `get_courses_ready_to_schedule()` instead of homegrown `is_ready_to_schedule` logic. My next PR will have a fixes for DIABLO-510 and https://jira.ets.berkeley.edu/jira/browse/DIABLO-487