### PR TITLE
DIABLO-512, new UX for course changes page

### DIFF
--- a/diablo/api/job_controller.py
+++ b/diablo/api/job_controller.py
@@ -84,6 +84,13 @@ def update_schedule():
     return tolerant_jsonify(job.to_api_json())
 
 
+@app.route('/api/job/<job_key>/last_successful_run')
+@admin_required
+def last_successful_run(job_key):
+    entry = JobHistory.last_successful_run_of(job_key=job_key)
+    return tolerant_jsonify(entry and entry.to_api_json())
+
+
 @app.route('/api/job/history')
 @admin_required
 def job_history():

--- a/diablo/models/job_history.py
+++ b/diablo/models/job_history.py
@@ -26,7 +26,7 @@ from datetime import datetime
 
 from diablo import db, std_commit
 from diablo.lib.util import to_isoformat
-from sqlalchemy import text
+from sqlalchemy import and_, text
 from sqlalchemy.sql import desc
 
 
@@ -76,6 +76,11 @@ class JobHistory(db.Model):
     @classmethod
     def get_job_history(cls):
         return cls.query.order_by(desc(cls.started_at)).all()
+
+    @classmethod
+    def last_successful_run_of(cls, job_key):
+        criteria = and_(cls.job_key == job_key, cls.failed == False, cls.finished_at != None)  # noqa: E711, E712
+        return cls.query.filter(criteria).order_by(desc(cls.finished_at)).limit(1).first()
 
     @staticmethod
     def fail_orphans():

--- a/src/api/job.ts
+++ b/src/api/job.ts
@@ -9,6 +9,10 @@ export function getJobSchedule() {
   return axios.get(`${utils.apiBaseUrl()}/api/job/schedule`)
 }
 
+export function getLastSuccessfulRun(jobKey) {
+  return axios.get(`${utils.apiBaseUrl()}/api/job/${jobKey}/last_successful_run`)
+}
+
 export function setJobDisabled(jobId, disable) {
   return axios.post(`${utils.apiBaseUrl()}/api/job/disable`, {
     jobId,

--- a/src/components/course/CourseRoom.vue
+++ b/src/components/course/CourseRoom.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="d-flex">
+    <v-tooltip
+      :id="`tooltip-course-${course.sectionId}-room-${room.id}-ineligible`"
+      bottom
+    >
+      <template v-slot:activator="{ on }">
+        <v-icon class="pr-1" :color="room.capability ? 'light-green' : 'yellow darken-2'" v-on="on">
+          {{ room.capability ? 'mdi-video-plus' : 'mdi-video-off-outline' }}
+        </v-icon>
+      </template>
+      {{ room.location }} is {{ room.capability ? '' : 'not' }} capture-enabled.
+    </v-tooltip>
+    <v-tooltip
+      v-if="!isInRoom(course, room)"
+      :id="`tooltip-course-${course.sectionId}-room-${room.id}-obsolete`"
+      bottom
+    >
+      <template v-slot:activator="{ on }">
+        <v-icon class="pr-1" color="yellow darken-2" v-on="on">mdi-map-marker-remove-outline</v-icon>
+      </template>
+      This course moved out of {{ room.location }}.
+    </v-tooltip>
+    <div>
+      <router-link
+        :id="`course-${course.sectionId}-room-${room.id}`"
+        :to="`/room/${room.id}`"
+      >
+        {{ room.location }}
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+  import Utils from '@/mixins/Utils'
+
+  export default {
+    name: 'CourseRoom',
+    mixins: [Utils],
+    props: {
+      course: {
+        required: true,
+        type: Object
+      },
+      room: {
+        required: true,
+        type: Object
+      }
+    }
+  }
+</script>

--- a/src/components/course/CoursesDataTable.vue
+++ b/src/components/course/CoursesDataTable.vue
@@ -92,22 +92,7 @@
               </td>
               <td :class="tdc(course)">
                 <div v-for="instructor in course.instructors" :key="instructor.uid" class="mb-1 mt-1">
-                  <v-tooltip v-if="instructor.approval" :id="`tooltip-approval-${course.sectionId}-by-${instructor.uid}`" bottom>
-                    <template v-slot:activator="{ on }">
-                      <v-icon
-                        :color="instructor.approval ? 'green' : 'yellow darken-2'"
-                        class="pa-0"
-                        dark
-                        v-on="on"
-                      >
-                        mdi-check
-                      </v-icon>
-                    </template>
-                    Approval submitted on {{ instructor.approval.createdAt | moment('MMM D, YYYY') }}.
-                  </v-tooltip>
-                  <router-link :id="`course-${course.sectionId}-instructor-${instructor.uid}-mailto`" :to="`/user/${instructor.uid}`">
-                    {{ instructor.name }}
-                  </router-link> ({{ instructor.uid }})
+                  <Instructor :course="course" :instructor="instructor" />
                 </div>
               </td>
               <td :id="`course-${course.sectionId}-publish-types`" :class="tdc(course)">
@@ -188,12 +173,13 @@
 
 <script>
   import Context from '@/mixins/Context'
+  import Instructor from '@/components/course/Instructor'
   import ToggleOptOut from '@/components/course/ToggleOptOut'
   import Utils from '@/mixins/Utils'
 
   export default {
     name: 'CoursesDataTable',
-    components: {ToggleOptOut},
+    components: {Instructor, ToggleOptOut},
     mixins: [Context, Utils],
     props: {
       courses: {

--- a/src/components/course/Instructor.vue
+++ b/src/components/course/Instructor.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="d-flex">
+    <v-tooltip
+      v-if="!$_.includes($_.map(course.instructors, 'uid'), instructor.uid)"
+      :id="`tooltip-course-${course.sectionId}-instructor-${instructor.uid}-approved`"
+      bottom
+    >
+      <template v-slot:activator="{ on }">
+        <v-icon class="pr-1" color="yellow darken-2" v-on="on">mdi-account-remove-outline</v-icon>
+      </template>
+      {{ instructor.name }} is no longer an instructor of this course.
+    </v-tooltip>
+    <v-tooltip
+      v-if="!instructor.approval && !instructor.wasSentInvite"
+      :id="`tooltip-course-${course.sectionId}-instructor-${instructor.uid}-not-invited`"
+      bottom
+    >
+      <template v-slot:activator="{ on }">
+        <v-icon class="pr-1" color="yellow darken-2" v-on="on">mdi-email-alert-outline</v-icon>
+      </template>
+      No invite has been sent to {{ instructor.name }}.
+    </v-tooltip>
+    <v-tooltip
+      v-if="instructor.approval"
+      :id="`tooltip-course-${course.sectionId}-instructor-${instructor.uid}-approved`"
+      bottom
+    >
+      <template v-slot:activator="{ on }">
+        <v-icon class="pr-1" color="green" v-on="on">mdi-check</v-icon>
+      </template>
+      Approval submitted on {{ instructor.approval.createdAt | moment('MMM D, YYYY') }}.
+    </v-tooltip>
+    <div>
+      <router-link :id="`course-${course.sectionId}-instructor-${instructor.uid}`" :to="`/user/${instructor.uid}`">
+        {{ instructor.name }}
+      </router-link> ({{ instructor.uid }})
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'Instructor',
+    props: {
+      course: {
+        required: true,
+        type: Object
+      },
+      instructor: {
+        required: true,
+        type: Object
+      }
+    }
+  }
+</script>

--- a/src/components/course/ObsoleteSchedule.vue
+++ b/src/components/course/ObsoleteSchedule.vue
@@ -1,0 +1,159 @@
+<template>
+  <v-container fluid>
+    <v-row no-gutters>
+      <v-card flat>
+        <router-link
+          :id="`link-course-${course.sectionId}`"
+          :to="`/course/${$config.currentTermId}/${course.sectionId}`"
+        >
+          <h2>{{ course.label }}</h2>
+        </router-link>
+        <div class="pt-2">
+          <h3 id="course-title">{{ course.courseTitle }}</h3>
+          Section ID: {{ course.sectionId }}
+        </div>
+      </v-card>
+    </v-row>
+    <v-row>
+      <v-col>
+        <v-card outlined tile>
+          <v-card-title>
+            <h4>Scheduled on {{ course.scheduled.createdAt | moment('MMM D, YYYY') }}</h4>
+          </v-card-title>
+          <v-card-subtitle>
+            {{ summary }}
+          </v-card-subtitle>
+          <v-card-text>
+            <div v-if="course.scheduled.hasObsoleteInstructors">
+              <h5>Obsolete Instructors</h5>
+              <div v-for="instructor in course.scheduled.instructors" :key="instructor.uid">
+                <Instructor :course="course" :instructor="instructor" />
+              </div>
+            </div>
+            <div :class="{'pt-2': course.scheduled.hasObsoleteInstructors}">
+              <h5>Meeting</h5>
+              <div>
+                <CourseRoom :course="course" :room="course.scheduled.room" />
+              </div>
+              <div v-if="!isRoomObsolete && (course.scheduled.hasObsoleteDates || course.scheduled.hasObsoleteTimes)">
+                <div class="d-flex pt-2">
+                  <v-tooltip
+                    v-if="course.scheduled.hasObsoleteDates"
+                    :id="`tooltip-course-${course.sectionId}-obsolete-dates`"
+                    bottom
+                  >
+                    <template v-slot:activator="{ on }">
+                      <v-icon class="pr-1" color="yellow darken-2" v-on="on">mdi-calendar-export</v-icon>
+                    </template>
+                    Meeting dates have changed.
+                  </v-tooltip>
+                  <div>
+                    {{ course.scheduled.meetingStartDate }} to {{ course.scheduled.meetingEndDate }}
+                  </div>
+                </div>
+                <div class="d-flex pt-2">
+                  <v-tooltip
+                    v-if="course.scheduled.hasObsoleteTimes"
+                    :id="`tooltip-course-${course.sectionId}-obsolete-times`"
+                    bottom
+                  >
+                    <template v-slot:activator="{ on }">
+                      <v-icon class="pr-1" color="yellow darken-2" v-on="on">mdi-clock-alert-outline</v-icon>
+                    </template>
+                    Meeting times have changed.
+                  </v-tooltip>
+                  <div>
+                    {{ $_.join(course.scheduled.meetingDays, ' ') }},
+                    {{ course.scheduled.meetingStartTimeFormatted }} - {{ course.scheduled.meetingEndTimeFormatted }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col>
+        <v-card outlined tile>
+          <v-card-title>
+            <h4>Current</h4>
+          </v-card-title>
+          <v-card-subtitle v-if="sisDataImportDate">
+            SIS Data last imported on {{ sisDataImportDate.finishedAt | moment('MMM D, YYYY') }}.
+          </v-card-subtitle>
+          <v-card-text>
+            <div v-if="course.scheduled.hasObsoleteInstructors">
+              <h5>Instructors</h5>
+              <div v-for="instructor in course.instructors" :key="instructor.uid">
+                <Instructor :course="course" :instructor="instructor" />
+              </div>
+            </div>
+            <div :class="{'pt-2': course.scheduled.hasObsoleteInstructors}">
+              <h5>All Meetings</h5>
+              <div v-for="meeting in meetings" :key="meeting.location">
+                <CourseRoom :course="course" :room="meeting.room" />
+                <div v-if="!isRoomObsolete && (course.scheduled.hasObsoleteDates || course.scheduled.hasObsoleteTimes)">
+                  <div class="d-flex pt-2">
+                    <div>
+                      {{ meeting.startDate }} to {{ meeting.endDate }}
+                    </div>
+                  </div>
+                  <div class="d-flex">
+                    <div class="pt-2">
+                      {{ $_.join(meeting.daysFormatted, ' ') }},
+                      {{ meeting.startTimeFormatted }} - {{ meeting.endTimeFormatted }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+  import CourseRoom from '@/components/course/CourseRoom'
+  import Instructor from '@/components/course/Instructor'
+  import Utils from '@/mixins/Utils'
+  import {getLastSuccessfulRun} from '@/api/job'
+
+  export default {
+    name: 'ObsoleteSchedule',
+    mixins: [Utils],
+    components: {Instructor, CourseRoom},
+    props: {
+      course: {
+        required: true,
+        type: Object
+      }
+    },
+    data: () => ({
+      meetings: undefined,
+      isRoomObsolete: undefined,
+      sisDataImportDate: undefined,
+      summary: undefined
+    }),
+    created() {
+      const hasObsoleteRoom = this.course.scheduled.hasObsoleteRoom
+      let considerations = {
+        instructors: this.course.scheduled.hasObsoleteInstructors,
+        room: hasObsoleteRoom
+      }
+      if (!hasObsoleteRoom) {
+        considerations = {...considerations, ...{
+          dates: this.course.scheduled.hasObsoleteDates,
+          times: this.course.scheduled.hasObsoleteTimes
+        }}
+      }
+      const obsoleteItems = this.$_.keys(this.$_.pickBy(considerations))
+      this.summary = this.$_.capitalize(`${this.oxfordJoin(obsoleteItems)} ${hasObsoleteRoom && obsoleteItems.length === 1 ? 'is' : 'are'} obsolete.`)
+      this.meetings = this.course.meetings.eligible.concat(this.course.meetings.ineligible)
+      this.isRoomObsolete = !this.isInRoom(this.course, this.course.scheduled.room)
+      getLastSuccessfulRun('sis_data_refresh').then(data => {
+        this.sisDataImportDate = data
+      })
+    }
+  }
+</script>

--- a/src/mixins/Utils.vue
+++ b/src/mixins/Utils.vue
@@ -20,6 +20,10 @@
         _.each(obj, (text, value) => options.push({text, value, disabled: isDisabled(value)}))
         return options
       },
+      isInRoom(course, room) {
+        const meetings = course.meetings.eligible.concat(course.meetings.ineligible)
+        return _.includes(_.map(meetings, 'room.id'), room.id)
+      },
       goToPath(path) {
         this.$router.push({ path }, _.noop)
       },

--- a/src/views/CourseChanges.vue
+++ b/src/views/CourseChanges.vue
@@ -2,9 +2,15 @@
   <v-card v-if="!loading" outlined class="elevation-1">
     <v-card-title class="align-start">
       <div class="pt-2">
-        <h1><v-icon class="pb-3" large>mdi-swap-horizontal</v-icon> Course Changes</h1>
+        <h1><v-icon class="pl-2" large>mdi-swap-horizontal</v-icon> Course Changes</h1>
       </div>
     </v-card-title>
+    <v-card-text v-if="courses.length">
+      <ObsoleteSchedule v-for="course in courses" :key="course.sectionId" :course="course" />
+    </v-card-text>
+    <v-card-text v-if="!courses.length" class="ma-4 text-no-wrap title">
+      No changes within scheduled courses.
+    </v-card-text>
     <v-data-table
       disable-pagination
       :headers="headers"
@@ -121,22 +127,7 @@
             <td>
               <div v-if="course.scheduled.hasObsoleteInstructors">
                 <div v-for="instructor in course.scheduled.instructors" :key="instructor.uid">
-                  <v-tooltip v-if="instructor.approval" :id="`tooltip-approval-${course.sectionId}-by-${instructor.uid}`" bottom>
-                    <template v-slot:activator="{ on }">
-                      <v-icon
-                        :color="instructor.approval ? 'green' : 'yellow darken-2'"
-                        class="pa-0"
-                        dark
-                        v-on="on"
-                      >
-                        mdi-check
-                      </v-icon>
-                    </template>
-                    Approval submitted on {{ instructor.approval.createdAt | moment('MMM D, YYYY') }}.
-                  </v-tooltip>
-                  <router-link :id="`instructor-${instructor.uid}-mailto`" :to="`/user/${instructor.uid}`">
-                    {{ instructor.name }}
-                  </router-link> ({{ instructor.uid }})
+                  <Instructor :course="course" :instructor="instructor" />
                 </div>
                 <div class="primary--text">
                   <v-icon small color="primary">mdi-arrow-down-bold</v-icon>
@@ -144,37 +135,7 @@
                 </div>
               </div>
               <div v-for="instructor in course.instructors" :key="instructor.uid">
-                <v-tooltip v-if="instructor.approval" :id="`tooltip-approval-${course.sectionId}-by-${instructor.uid}`" bottom>
-                  <template v-slot:activator="{ on }">
-                    <v-icon
-                      :color="instructor.approval ? 'green' : 'yellow darken-2'"
-                      class="pa-0"
-                      dark
-                      v-on="on"
-                    >
-                      mdi-check
-                    </v-icon>
-                  </template>
-                  Approval submitted on {{ instructor.approval.createdAt | moment('MMM D, YYYY') }}.
-                </v-tooltip>
-                <v-tooltip v-if="!instructor.wasSentInvite" bottom>
-                  <template v-slot:activator="{ on }">
-                    <v-icon
-                      color="yellow darken-2"
-                      class="pb-1 pl-1"
-                      dark
-                      v-on="on"
-                    >
-                      mdi-alert-circle-outline
-                    </v-icon>
-                  </template>
-                  <div>
-                    No invite sent to {{ instructor.name }}.
-                  </div>
-                </v-tooltip>
-                <router-link :id="`instructor-${instructor.uid}-mailto`" :to="`/user/${instructor.uid}`">
-                  {{ instructor.name }}
-                </router-link> ({{ instructor.uid }})
+                <Instructor :course="course" :instructor="instructor" />
               </div>
             </td>
           </tr>
@@ -186,11 +147,15 @@
 
 <script>
   import Context from '@/mixins/Context'
+  import Instructor from '@/components/course/Instructor'
+  import ObsoleteSchedule from '@/components/course/ObsoleteSchedule'
+  import Utils from '@/mixins/Utils'
   import {getCourseChanges} from '@/api/course'
 
   export default {
     name: 'CourseChanges',
-    mixins: [Context],
+    mixins: [Context, Utils],
+    components: {Instructor, ObsoleteSchedule},
     data: () => ({
       courses: undefined,
       headers: [


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-512

Overhaul of course-changes page. (The old UX is still present, down the page from this new UX. The old will be removed if the new is judged as better.) In this design, if scheduled room is obsolete then we do not show scheduled dates and times, because a room change makes that other info irrelevant. 

Notice in screenshot that much is communicated via icons. Mouse-over icon always gives info. The hope is that Willa will become versed in semantics o' icon.

![image](https://user-images.githubusercontent.com/7606442/87254360-f7a0a580-c436-11ea-800b-18a1ac9ba895.png)
