### PR TITLE
DIABLO-514, certain sis_section queries (course-changes; already-scheduled) tolerate null instructor-uid

### DIFF
--- a/diablo/lib/development_db_utils.py
+++ b/diablo/lib/development_db_utils.py
@@ -44,10 +44,15 @@ def _load_mock_courses(json_file_path):
         instructors = json_['instructors']
         courses = []
         for c in json_['courses']:
-            c['instructor_name'] = instructors[c['instructor_uid']]
             for key, value in defaults.items():
                 if key not in c:
                     c[key] = value
+            uid = c['instructor_uid']
+            if uid:
+                c['instructor_name'] = instructors[uid]
+            else:
+                c['instructor_name'] = None
+                c['instructor_role_code'] = None
             courses.append(c)
         return courses
 

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -169,7 +169,7 @@ class SisSection(db.Model):
                 s.term_id = :term_id
                 AND s.is_primary IS TRUE
                 AND s.section_id = :section_id
-                AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
                 AND s.is_principal_listing IS TRUE
             ORDER BY s.course_name, s.section_id, s.instructor_uid, r.capability NULLS LAST
         """
@@ -201,7 +201,7 @@ class SisSection(db.Model):
             WHERE
                 s.term_id = :term_id
                 AND s.is_primary IS TRUE
-                AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
                 AND s.is_principal_listing IS TRUE
             ORDER BY s.course_name, s.section_id, s.instructor_uid, r.capability NULLS LAST
         """
@@ -285,8 +285,10 @@ class SisSection(db.Model):
                 r.location AS room_location
             FROM sis_sections s
             JOIN rooms r ON r.location = s.meeting_location
-                AND s.term_id = :term_id AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
-                AND s.is_primary IS TRUE AND s.is_principal_listing IS TRUE
+                AND s.term_id = :term_id
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
+                AND s.is_primary IS TRUE
+                AND s.is_principal_listing IS TRUE
             JOIN sent_emails e ON e.section_id = s.section_id AND e.template_type = 'invitation'
             LEFT JOIN instructors i ON i.uid = s.instructor_uid
             -- Omit approved courses, scheduled courses and opt-outs.
@@ -351,7 +353,7 @@ class SisSection(db.Model):
             FROM sis_sections s
             JOIN rooms r ON r.location = s.meeting_location
                 AND s.term_id = :term_id
-                AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
                 AND s.is_primary IS TRUE
                 AND s.is_principal_listing IS TRUE
                 AND s.section_id IN ({_sections_with_at_least_one_eligible_room()})
@@ -430,8 +432,8 @@ class SisSection(db.Model):
                 r.id AS room_id,
                 r.location AS room_location
             FROM sis_sections s
-            JOIN approvals a
-                ON s.term_id = :term_id AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
+            JOIN approvals a ON s.term_id = :term_id
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
                 AND s.is_primary IS TRUE AND s.is_principal_listing IS TRUE
                 AND a.section_id = s.section_id AND a.term_id = :term_id AND a.deleted_at IS NULL
                 AND (
@@ -516,8 +518,10 @@ class SisSection(db.Model):
                 r.location AS room_location
             FROM sis_sections s
             JOIN rooms r ON r.location = s.meeting_location
-                AND s.term_id = :term_id AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
-                AND s.is_primary IS TRUE AND s.is_principal_listing IS TRUE
+                AND s.term_id = :term_id
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
+                AND s.is_primary IS TRUE
+                AND s.is_principal_listing IS TRUE
                 AND s.meeting_location = :location
             LEFT JOIN instructors i ON i.uid = s.instructor_uid
             ORDER BY CASE LEFT(s.meeting_days, 2)
@@ -589,8 +593,10 @@ class SisSection(db.Model):
         sql = """
             SELECT DISTINCT s.section_id
             FROM sis_sections s
-            WHERE s.term_id = :term_id AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
-                AND s.is_primary IS TRUE AND s.is_principal_listing IS TRUE
+            WHERE s.term_id = :term_id
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
+                AND s.is_primary IS TRUE
+                AND s.is_principal_listing IS TRUE
                 AND (s.meeting_start_date::text NOT LIKE :term_begin OR s.meeting_end_date::text NOT LIKE :term_end)
             ORDER BY s.section_id
         """
@@ -610,8 +616,10 @@ class SisSection(db.Model):
             SELECT DISTINCT s.section_id
             FROM sis_sections s
             JOIN rooms r ON r.location = s.meeting_location
-                AND s.term_id = :term_id AND s.instructor_role_code IN ('ICNT', 'PI', 'TNIC')
-                AND s.is_primary IS TRUE AND s.is_principal_listing IS TRUE
+                AND s.term_id = :term_id
+                AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
+                AND s.is_primary IS TRUE
+                AND s.is_principal_listing IS TRUE
             JOIN scheduled d ON d.section_id = s.section_id AND d.term_id = :term_id AND d.deleted_at IS NULL
             LEFT JOIN instructors i ON i.uid = s.instructor_uid
             ORDER BY s.section_id

--- a/fixtures/sis/courses.json
+++ b/fixtures/sis/courses.json
@@ -331,6 +331,19 @@
       "course_name": "COMPSCI 161 LEC 001 (hybrid instruction)",
       "course_title": "Computer Security",
       "section_id": 50016
+    },
+    {
+      "allowed_units": "3.0",
+      "instructor_uid": null,
+      "meeting_days": "TUTH",
+      "meeting_end_date": "2020-12-11",
+      "meeting_end_time": "11:59",
+      "meeting_location": "Barker 101",
+      "meeting_start_date": "2020-08-26",
+      "meeting_start_time": "11:00",
+      "course_name": "MUSIC 25",
+      "course_title": "Introduction to Music Theory",
+      "section_id": 50017
     }
   ]
 }

--- a/src/components/course/CoursesDataTable.vue
+++ b/src/components/course/CoursesDataTable.vue
@@ -91,8 +91,13 @@
                 <div :id="`course-${course.sectionId}-scheduling-status`">{{ course.schedulingStatus || '&mdash;' }}</div>
               </td>
               <td :class="tdc(course)">
-                <div v-for="instructor in course.instructors" :key="instructor.uid" class="mb-1 mt-1">
-                  <Instructor :course="course" :instructor="instructor" />
+                <div v-if="course.instructors.length">
+                  <div v-for="instructor in course.instructors" :key="instructor.uid" class="mb-1 mt-1">
+                    <Instructor :course="course" :instructor="instructor" />
+                  </div>
+                </div>
+                <div v-if="!course.instructors.length">
+                  &mdash;
                 </div>
               </td>
               <td :id="`course-${course.sectionId}-publish-types`" :class="tdc(course)">

--- a/src/components/course/ObsoleteSchedule.vue
+++ b/src/components/course/ObsoleteSchedule.vue
@@ -86,8 +86,13 @@
           <v-card-text>
             <div v-if="course.scheduled.hasObsoleteInstructors">
               <h5>Instructors</h5>
-              <div v-for="instructor in course.instructors" :key="instructor.uid">
-                <Instructor :course="course" :instructor="instructor" />
+              <div v-if="course.instructors.length">
+                <div v-for="instructor in course.instructors" :key="instructor.uid">
+                  <Instructor :course="course" :instructor="instructor" />
+                </div>
+              </div>
+              <div v-if="!course.instructors.length">
+                None
               </div>
             </div>
             <div


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-514

Queries in which we tolerate null instructor:
- get_course
- get_course_changes
- get_courses_invited
- get_courses_opted_out
- get_courses_queued_for_scheduling
- get_courses_per_location

I have a test to verify invitations_job skips null instructors.

