### PR TITLE
DIABLO-521, split is_schedule_obsolete into separate date and time checks

### DIFF
--- a/diablo/jobs/admin_emails_job.py
+++ b/diablo/jobs/admin_emails_job.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 from diablo.jobs.base_job import BaseJob
 from diablo.jobs.errors import BackgroundJobError
-from diablo.lib.berkeley import is_schedule_obsolete
+from diablo.lib.berkeley import are_scheduled_dates_obsolete, are_scheduled_times_obsolete
 from diablo.lib.interpolator import interpolate_content
 from diablo.merged.emailer import get_admin_alert_recipient
 from diablo.models.email_template import EmailTemplate
@@ -69,7 +69,10 @@ class AdminEmailsJob(BaseJob):
         for course in self._get_courses_except_notified(template_type):
             meetings = course.get('meetings', {}).get('eligible', [])
             if len(meetings):
-                if is_schedule_obsolete(meeting=meetings[0], scheduled=course['scheduled']):
+                meeting = meetings[0]
+                scheduled = course['scheduled']
+                obsolete_dates = are_scheduled_dates_obsolete(meeting=meeting, scheduled=scheduled)
+                if obsolete_dates or are_scheduled_times_obsolete(meeting=meeting, scheduled=scheduled):
                     self._notify(course=course, template_type=template_type)
 
     def _instructor_change_alerts(self):

--- a/src/components/course/ObsoleteSchedule.vue
+++ b/src/components/course/ObsoleteSchedule.vue
@@ -104,7 +104,10 @@
                 <CourseRoom :course="course" :room="meeting.room" />
                 <div v-if="!isRoomObsolete && (course.scheduled.hasObsoleteDates || course.scheduled.hasObsoleteTimes)" class="pb-2">
                   <div class="d-flex">
-                    <div>
+                    <div v-if="meeting.eligible">
+                      {{ meeting.recordingStartDate }} to {{ meeting.recordingEndDate }}
+                    </div>
+                    <div v-if="!meeting.eligible">
                       {{ meeting.startDate }} to {{ meeting.endDate }}
                     </div>
                   </div>

--- a/tests/test_api/api_test_utils.py
+++ b/tests/test_api/api_test_utils.py
@@ -81,6 +81,7 @@ def mock_scheduled(
         section_id,
         term_id,
         meeting=None,
+        override_days=None,
         override_end_date=None,
         override_end_time=None,
         override_room_id=None,
@@ -93,7 +94,7 @@ def mock_scheduled(
     Scheduled.create(
         instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
         kaltura_schedule_id=random.randint(1, 10),
-        meeting_days=meeting['days'],
+        meeting_days=override_days or meeting['days'],
         meeting_end_date=override_end_date or get_recording_end_date(meeting),
         meeting_end_time=override_end_time or meeting['endTime'],
         meeting_start_date=override_start_date or get_recording_start_date(meeting, return_today_if_past_start=True),

--- a/tests/test_jobs/test_admin_emails_job.py
+++ b/tests/test_jobs/test_admin_emails_job.py
@@ -29,7 +29,8 @@ from diablo.jobs.admin_emails_job import AdminEmailsJob
 from diablo.jobs.canvas_job import CanvasJob
 from diablo.jobs.doomed_to_failure import DoomedToFailure
 from diablo.jobs.queued_emails_job import QueuedEmailsJob
-from diablo.lib.berkeley import get_recording_end_date, get_recording_start_date, is_schedule_obsolete
+from diablo.lib.berkeley import are_scheduled_dates_obsolete, are_scheduled_times_obsolete, get_recording_end_date, \
+    get_recording_start_date
 from diablo.models.approval import Approval
 from diablo.models.job import Job
 from diablo.models.queued_email import QueuedEmail
@@ -66,7 +67,9 @@ class TestAdminEmailsJob:
                                 term_id=term_id,
                             )
                             course = SisSection.get_course(section_id=section_id, term_id=term_id)
-                            assert is_schedule_obsolete(meeting=meeting, scheduled=course['scheduled'])
+                            scheduled = course['scheduled']
+                            assert are_scheduled_dates_obsolete(meeting=meeting, scheduled=scheduled) is False
+                            assert are_scheduled_times_obsolete(meeting=meeting, scheduled=scheduled) is True
 
                         def _assert_alert_count(count):
                             emails_sent = SentEmail.get_emails_sent_to(uid=admin_uid)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-521

The bug was in `sis_section` feed:
```
'hasObsoleteDates': is_schedule_obsolete(meeting=meeting, scheduled=scheduled),
```
A change in days/times was producing `True` above and that is wrong. I fixed and adjusted logic in `AdminEmailsJob`.