### PR TITLE
DIABLO-544, API endpoint to get Kaltura metadata per canvas_course_site_id

### DIFF
--- a/diablo/api/kaltura_controller.py
+++ b/diablo/api/kaltura_controller.py
@@ -1,0 +1,34 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+from diablo.api.util import admin_required
+from diablo.externals.kaltura import Kaltura
+from diablo.lib.http import tolerant_jsonify
+from flask import current_app as app
+
+
+@app.route('/api/kaltura/category/canvas/<course_site_id>')
+@admin_required
+def kaltura_category_canvas(course_site_id):
+    return tolerant_jsonify(Kaltura().get_canvas_category_object(canvas_course_site_id=course_site_id))

--- a/diablo/routes.py
+++ b/diablo/routes.py
@@ -44,6 +44,7 @@ def register_routes(app):
     import diablo.api.course_controller
     import diablo.api.email_controller
     import diablo.api.job_controller
+    import diablo.api.kaltura_controller
     import diablo.api.room_controller
     import diablo.api.status_controller
     import diablo.api.user_controller

--- a/tests/test_api/test_kaltura_controller.py
+++ b/tests/test_api/test_kaltura_controller.py
@@ -1,0 +1,50 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+import pytest
+
+instructor_uid = '00001'
+
+
+@pytest.fixture()
+def instructor_session(fake_auth):
+    fake_auth.login(instructor_uid)
+
+
+class TestGetKalturaCategoryCanvas:
+    """Only Admin users can get Kaltura category metadata."""
+
+    @staticmethod
+    def _api_kaltura_category_canvas(client, expected_status_code=200):
+        response = client.get('/api/kaltura/category/canvas/123456')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_anonymous(self, client):
+        """Denies anonymous access."""
+        self._api_kaltura_category_canvas(client, expected_status_code=401)
+
+    def test_unauthorized(self, client, instructor_session):
+        """Denies access if user is not an admin."""
+        self._api_kaltura_category_canvas(client, expected_status_code=401)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-544

A quick answer to question, does Kaltura know about this course site?