### PR TITLE
DIABLO-548, courses with zero instructors show up on /ouija

### DIFF
--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -562,9 +562,10 @@ class TestGetCourses:
             self._create_approval(section_4_id)
             std_commit(allow_test_environment=True)
             api_json = self._api_courses(client, term_id=self.term_id, filter_='Not Invited')
-            assert not _find_course(api_json=api_json, section_id=eligible_course_with_no_instructors)
             assert not _find_course(api_json=api_json, section_id=section_1_id)
             assert not _find_course(api_json=api_json, section_id=section_4_id)
+            # Zero instructors is acceptable
+            assert _find_course(api_json=api_json, section_id=eligible_course_with_no_instructors)
             # Third course is in enabled room and has not received an invite. Therefore, it is in the feed.
             assert _is_course_in_enabled_room(section_id=section_3_id, term_id=self.term_id)
             course = _find_course(api_json=api_json, section_id=section_3_id)
@@ -653,7 +654,7 @@ class TestGetCourses:
             std_commit(allow_test_environment=True)
             # We gotta catch 'em all.
             api_json = self._api_courses(client, term_id=self.term_id, filter_='All')
-            assert len(api_json) == 10
+            assert len(api_json) == 11
             for section_id in [section_1_id, section_3_id, section_4_id, section_5_id, section_6_id]:
                 assert _find_course(api_json=api_json, section_id=section_id)
             assert not _find_course(api_json=api_json, section_id=section_in_ineligible_room)

--- a/tests/test_jobs/test_invitation_job.py
+++ b/tests/test_jobs/test_invitation_job.py
@@ -51,7 +51,7 @@ class TestInvitationJob:
 
             # Each eligible course has an invitation.
             eligible_courses = [c for c in SisSection.get_courses(term_id=term_id) if len(c['meetings']['eligible']) == 1]
-            assert len(eligible_courses) == 10
+            assert len(eligible_courses) == 11
             for course in eligible_courses:
                 for i in course['instructors']:
                     sent_email = next((e for e in invitations if e.section_id == course['sectionId'] and i['uid'] == e.recipient_uid), None)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-548

Changes:
* cleaned up SQL formatting
* `get_courses` query now uses `instructor_uid IS NULL OR instructor_role_code IN ('ICNT', 'PI', 'TNIC')`
* I decided not to touch the complex `get_courses_partially_approved` query.  A course with zero instructors and approvals in the past will not show up in the associated filter.