### PR TITLE
DIABLO-560, do not fetch courses_per_uid every time flask_login loads user

### DIFF
--- a/diablo/api/auth_controller.py
+++ b/diablo/api/auth_controller.py
@@ -59,7 +59,7 @@ def dev_auth_login():
             msg = f'The system failed to log in user with UID {uid}.'
             app.logger.error(msg)
             return tolerant_jsonify({'message': msg}, 403)
-        return tolerant_jsonify(current_user.to_api_json())
+        return tolerant_jsonify(current_user.to_api_json(include_courses=True))
     else:
         raise ResourceNotFoundError('Unknown path')
 

--- a/diablo/api/user_controller.py
+++ b/diablo/api/user_controller.py
@@ -34,7 +34,7 @@ from flask_login import current_user
 
 @app.route('/api/user/my_profile')
 def my_profile():
-    return tolerant_jsonify(current_user.to_api_json())
+    return tolerant_jsonify(current_user.to_api_json(include_courses=True))
 
 
 @app.route('/api/user/<uid>')

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -641,6 +641,26 @@ class SisSection(db.Model):
         return cls.get_course(section_id=section_id, term_id=term_id)
 
     @classmethod
+    def is_teaching(cls, term_id, uid):
+        sql = """
+            SELECT id
+            FROM sis_sections
+            WHERE term_id = :term_id
+                AND is_primary IS TRUE
+                AND instructor_uid = :uid
+                AND instructor_role_code IN ('ICNT', 'PI', 'TNIC')
+            LIMIT 1
+        """
+        results = db.session.execute(
+            text(sql),
+            {
+                'uid': uid,
+                'term_id': term_id,
+            },
+        )
+        return results.rowcount > 0
+
+    @classmethod
     def _section_ids_with_nonstandard_dates(cls, term_id):
         if str(term_id) != str(app.config['CURRENT_TERM_ID']):
             app.logger.warn(f'Dates for term id {term_id} not configured; cannot query for nonstandard dates.')

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -117,6 +117,8 @@ class TestDevAuth:
                 },
             )
             assert api_json['uid'] == admin_uid
+            assert api_json['isTeaching'] is False
+            assert len(api_json['courses']) == 0
             response = client.get('/api/auth/logout')
             assert response.status_code == 200
             assert response.json['isAnonymous']
@@ -132,6 +134,8 @@ class TestDevAuth:
                 },
             )
             assert api_json['uid'] == instructor_uid
+            assert api_json['isTeaching'] is True
+            assert len(api_json['courses']) > 0
             response = client.get('/api/auth/logout')
             assert response.status_code == 200
             assert response.json['isAnonymous']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-560

Previously, the `courses_per_uid` query happened 2-3 times per front-end view. Does not scale well.