### PR TITLE
DIABLO-471, SQL tweak to non-standard filter: odd start_date is relevant only if scheduled beforehand

### DIFF
--- a/diablo/lib/development_db_utils.py
+++ b/diablo/lib/development_db_utils.py
@@ -67,8 +67,9 @@ def _save_courses(sis_sections):
         )
         SELECT
             allowed_units, course_name, course_title, created_at, instruction_format, instructor_name,
-            instructor_role_code, instructor_uid, is_primary, meeting_days, meeting_end_date, meeting_end_time,
-            meeting_location, meeting_start_date, meeting_start_time, section_id, section_num, term_id
+            instructor_role_code, instructor_uid, is_primary::BOOLEAN, meeting_days, meeting_end_date::TIMESTAMP,
+            meeting_end_time, meeting_location, meeting_start_date::TIMESTAMP, meeting_start_time, section_id::INTEGER,
+            section_num, term_id::INTEGER
         FROM json_populate_recordset(null::sis_sections, :json_dumps)
     """
     data = [

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -668,11 +668,16 @@ class SisSection(db.Model):
         sql = """
             SELECT DISTINCT s.section_id
             FROM sis_sections s
+            JOIN scheduled d ON d.section_id = s.section_id
+                AND d.term_id = s.term_id
             WHERE s.term_id = :term_id
                 AND (s.instructor_uid IS NULL OR s.instructor_role_code IN ('ICNT', 'PI', 'TNIC'))
                 AND s.is_primary IS TRUE
                 AND s.is_principal_listing IS TRUE
-                AND (s.meeting_start_date::text NOT LIKE :term_begin OR s.meeting_end_date::text NOT LIKE :term_end)
+                AND (
+                    (s.meeting_start_date::text NOT LIKE :term_begin AND d.created_at < s.meeting_start_date)
+                    OR s.meeting_end_date::text NOT LIKE :term_end
+                )
             ORDER BY s.section_id
         """
         rows = db.session.execute(


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-471

Also, I added SQL-type cast in load-mock-courses in order to match `sis_sections.template.sql`.