### PR TITLE
DIABLO-554, 'TimeOut 600' in Apache config for long running jobs

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -67,7 +67,7 @@ files:
           group=wsgi
         WSGIProcessGroup wsgi-ssl
 
-        TimeOut 300
+        TimeOut 600
 
       </VirtualHost>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-554

This kind of fix worked for DIABLO-364. We now have secondary sections in the mix and certain jobs (eg, Canvas) take longer. I'm increasing timeout to 10 min. If this problem happens again then we'll probably want to introduce job_status polling in Diablo.