### PR TITLE
DIABLO-593, programmatically get canvas_enrollment_term_id per CURRENT_TERM_ID config

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -44,7 +44,6 @@ CANVAS_API_URL = 'https://hard_knocks_api.instructure.com'
 CANVAS_BASE_URL = 'https://ucberkeley.foo.instructure.com'
 CANVAS_BERKELEY_ACCOUNT_ID = 00000
 CANVAS_BERKELEY_SUB_ACCOUNTS = [00000]
-CANVAS_ENROLLMENT_TERM_ID = 0000
 
 CANVAS_LTI_EXTERNAL_TOOL_IDS = {
     'media_gallery': 1,

--- a/diablo/externals/canvas.py
+++ b/diablo/externals/canvas.py
@@ -27,6 +27,7 @@ import re
 from canvasapi import Canvas
 from canvasapi.external_tool import ExternalTool
 from diablo import skip_when_pytest
+from diablo.lib.berkeley import get_canvas_sis_term_id
 from diablo.lib.util import resolve_xml_template
 from flask import current_app as app
 
@@ -55,6 +56,17 @@ def get_canvas_course_sites(canvas_enrollment_term_id):
                         }
                     course_sites_by_id[course_site_id]['section_ids'].add(section_id)
     return list(course_sites_by_id.values())
+
+
+@skip_when_pytest(mock_object=type('EnrollmentTerm', (object,), {'id': 9999}))
+def get_canvas_enrollment_term(sis_term_id):
+    canvas_sis_term_id = get_canvas_sis_term_id(sis_term_id)
+    canvas_enrollment_term = None
+    for enrollment_term in _get_canvas().get_enrollment_terms():
+        if enrollment_term.sis_term_id == canvas_sis_term_id:
+            canvas_enrollment_term = enrollment_term
+            break
+    return canvas_enrollment_term
 
 
 def ping_canvas():

--- a/diablo/lib/berkeley.py
+++ b/diablo/lib/berkeley.py
@@ -105,6 +105,19 @@ def term_name_for_sis_id(sis_id=None):
         return f'{season_codes[sis_id[3:4]]} {year}'
 
 
+def get_canvas_sis_term_id(sis_id=None):
+    if sis_id:
+        sis_id = str(sis_id)
+        season_codes = {
+            '0': 'A',
+            '2': 'B',
+            '5': 'C',
+            '8': 'D',
+        }
+        year = f'19{sis_id[1:3]}' if sis_id.startswith('1') else f'20{sis_id[1:3]}'
+        return f'TERM:{year}-{season_codes[sis_id[3:4]]}'
+
+
 def are_scheduled_dates_obsolete(meeting, scheduled):
     if meeting:
         def _format(date):

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -25,13 +25,25 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime, timedelta
 
 from diablo.lib.berkeley import are_scheduled_dates_obsolete, are_scheduled_times_obsolete, DAYS, \
-    get_first_matching_datetime_of_term, get_recording_end_date, get_recording_start_date
+    get_canvas_sis_term_id, get_first_matching_datetime_of_term, get_recording_end_date, get_recording_start_date, \
+    term_name_for_sis_id
 from diablo.lib.util import format_days
 from diablo.models.sis_section import SisSection
 from flask import current_app as app
 import pytz
 from tests.test_api.api_test_utils import mock_scheduled
 from tests.util import override_config, test_approvals_workflow
+
+
+class TestTermIds:
+
+    def test_term_name_for_sis_id(self):
+        assert term_name_for_sis_id('2208') == 'Fall 2020'
+        assert term_name_for_sis_id('2212') == 'Spring 2021'
+
+    def test_get_canvas_sis_term_id(self):
+        assert get_canvas_sis_term_id('2208') == 'TERM:2020-D'
+        assert get_canvas_sis_term_id('2212') == 'TERM:2021-B'
 
 
 class TestRecordingDates:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-593

Maintaining CANVAS_ENROLLMENT_TERM_ID config is prone to error. Deducing on the fly ain't hard.
