### PR TITLE
DIABLO-600, Kaltura API: get_events_by_location order by startDate

### DIFF
--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -150,7 +150,10 @@ class Kaltura:
 
     @skip_when_pytest()
     def get_events_by_location(self, kaltura_resource_id):
-        event_filter = KalturaScheduleEventFilter(resourceIdEqual=str(kaltura_resource_id))
+        event_filter = KalturaScheduleEventFilter(
+            orderBy='-startDate',
+            resourceIdEqual=str(kaltura_resource_id),
+        )
         return self._get_events(kaltura_event_filter=event_filter)
 
     @skip_when_pytest()


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-600

The leading dash is intentional (see [related post](https://stackoverflow.com/questions/50489593/orderby-filter-not-working-for-kaltura-media-listing-api-using)). 