### PR TITLE
DIABLO-628, add 'blackouts' job to db

### DIFF
--- a/scripts/db/migrate/2021/20210601-DIABLO-628/add_blackouts_job.sql
+++ b/scripts/db/migrate/2021/20210601-DIABLO-628/add_blackouts_job.sql
@@ -1,0 +1,31 @@
+/**
+ * Copyright ©2021. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+INSERT INTO jobs (disabled, job_schedule_type, job_schedule_value,key, created_at, updated_at)
+VALUES (TRUE, 'day_at', '05:00', 'blackouts', now(), now());
+
+COMMIT;

--- a/src/views/blackout/Blackouts.vue
+++ b/src/views/blackout/Blackouts.vue
@@ -43,9 +43,6 @@
                   <td :id="`blackout-${blackout.id}-end-date`">
                     {{ blackout.endDate }}
                   </td>
-                  <td class="text-no-wrap">
-                    {{ blackout.createdAt | moment('MMM DD, YYYY') }}
-                  </td>
                   <td>
                     <v-btn
                       :id="`delete-blackout-${blackout.id}`"
@@ -82,7 +79,6 @@ export default {
       {text: 'Name', value: 'name'},
       {text: 'Start Date', value: 'startDate'},
       {text: 'End Date', value: 'endDate'},
-      {text: 'Created', value: 'createdAt'},
       {text: 'Delete', class: 'pl-5 pr-0 mr-0'}
     ],
     refreshing: false


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-628

And, no need to show 'createdAt' on /blackouts page.  It might get confused with the blackout date range.

Release instructions updated with db modify script in this PR.
