### PR TITLE
DIABLO-649, AWS linux-2: remove obsolete 'aws:elasticbeanstalk:container:python:staticfiles' config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -19,9 +19,6 @@ option_settings:
     NumProcesses: 1
     NumThreads: 15
 
-  aws:elasticbeanstalk:container:python:staticfiles:
-    /static/: dist/static/
-
   aws:elasticbeanstalk:application:environment:
     DIABLO_ENV: production
     PYTHONPATH: "/opt/python/current/app/diablo:$PYTHONPATH"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-649

