### PR TITLE
DIABLO-677, add course_display_name to db: approvals and scheduled

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Diablo supports UC Berkeley's Course Capture service.
 
 ## Installation
 
-* Install Python 3
+* Install Python 3.8
 * Create your virtual environment (venv)
 * Install dependencies
 

--- a/diablo/api/course_controller.py
+++ b/diablo/api/course_controller.py
@@ -80,6 +80,7 @@ def approve():
     approval = Approval.create(
         approved_by_uid=current_user.uid,
         approver_type_='admin' if current_user.is_admin else 'instructor',
+        course_display_name=course['label'],
         publish_type_=publish_type,
         recording_type_=recording_type,
         room_id=room.id,

--- a/diablo/jobs/util.py
+++ b/diablo/jobs/util.py
@@ -233,6 +233,7 @@ def schedule_recordings(all_approvals, course):
                 term_id=term_id,
             )
             scheduled = Scheduled.create(
+                course_display_name=course['label'],
                 instructor_uids=instructor_uids,
                 kaltura_schedule_id=kaltura_schedule_id,
                 meeting_days=meeting['days'],

--- a/diablo/models/approval.py
+++ b/diablo/models/approval.py
@@ -69,66 +69,72 @@ class Approval(db.Model):
     __tablename__ = 'approvals'
 
     id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
-    term_id = db.Column(db.Integer, nullable=False)
-    section_id = db.Column(db.Integer, nullable=False)
     approved_by_uid = db.Column(db.String, nullable=False)
     approver_type = db.Column(approver_type, nullable=False)
-    room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'), nullable=False)
-    publish_type = db.Column(publish_type, nullable=False)
-    recording_type = db.Column(recording_type, nullable=False)
+    course_display_name = db.Column(db.String, nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     deleted_at = db.Column(db.DateTime, nullable=True)
+    publish_type = db.Column(publish_type, nullable=False)
+    recording_type = db.Column(recording_type, nullable=False)
+    room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'), nullable=False)
+    section_id = db.Column(db.Integer, nullable=False)
+    term_id = db.Column(db.Integer, nullable=False)
 
     def __init__(
             self,
-            term_id,
-            section_id,
             approved_by_uid,
             approver_type_,
-            room_id,
+            course_display_name,
             publish_type_,
             recording_type_,
+            room_id,
+            section_id,
+            term_id,
     ):
-        self.term_id = term_id
-        self.section_id = section_id
         self.approved_by_uid = approved_by_uid
         self.approver_type = approver_type_
-        self.room_id = room_id
+        self.course_display_name = course_display_name
         self.publish_type = publish_type_
         self.recording_type = recording_type_
+        self.room_id = room_id
+        self.section_id = section_id
+        self.term_id = term_id
 
     def __repr__(self):
         return f"""<Approval
                     id={self.id},
-                    term_id={self.term_id},
-                    section_id={self.section_id},
                     approved_by_uid={self.approved_by_uid},
                     approver_type={self.approver_type},
+                    course_display_name={self.course_display_name},
+                    created_at={self.created_at},
                     publish_type={self.publish_type},
                     recording_type={self.recording_type},
                     room_id={self.room_id},
-                    created_at={self.created_at}>
+                    section_id={self.section_id},
+                    term_id={self.term_id}>
                 """
 
     @classmethod
     def create(
             cls,
-            term_id,
-            section_id,
             approved_by_uid,
             approver_type_,
+            course_display_name,
             publish_type_,
             recording_type_,
             room_id,
+            section_id,
+            term_id,
     ):
         approval = cls(
-            term_id=term_id,
-            section_id=section_id,
             approved_by_uid=approved_by_uid,
             approver_type_=approver_type_,
+            course_display_name=course_display_name,
             publish_type_=publish_type_,
             recording_type_=recording_type_,
             room_id=room_id,
+            section_id=section_id,
+            term_id=term_id,
         )
         db.session.add(approval)
         std_commit()
@@ -172,7 +178,7 @@ class Approval(db.Model):
                 room_feed = Room.get_room(self.room_id).to_api_json()
         return {
             'approvedBy': self.approved_by_uid,
-            'wasApprovedByAdmin': self.approver_type == 'admin',
+            'courseDisplayName': self.course_display_name,
             'createdAt': to_isoformat(self.created_at),
             'publishType': self.publish_type,
             'publishTypeName': NAMES_PER_PUBLISH_TYPE[self.publish_type],
@@ -181,6 +187,7 @@ class Approval(db.Model):
             'room': room_feed,
             'sectionId': self.section_id,
             'termId': self.term_id,
+            'wasApprovedByAdmin': self.approver_type == 'admin',
         }
 
 

--- a/diablo/models/scheduled.py
+++ b/diablo/models/scheduled.py
@@ -40,6 +40,7 @@ class Scheduled(db.Model):
     section_id = db.Column(db.Integer, nullable=False)
     term_id = db.Column(db.Integer, nullable=False)
     alerts = db.Column(ARRAY(email_template_type))
+    course_display_name = db.Column(db.String, nullable=False)
     instructor_uids = db.Column(ARRAY(db.String(80)), nullable=False)
     kaltura_schedule_id = db.Column(db.Integer, nullable=False)
     meeting_days = db.Column(db.String, nullable=False)
@@ -55,8 +56,7 @@ class Scheduled(db.Model):
 
     def __init__(
             self,
-            section_id,
-            term_id,
+            course_display_name,
             instructor_uids,
             kaltura_schedule_id,
             meeting_days,
@@ -67,9 +67,10 @@ class Scheduled(db.Model):
             publish_type_,
             recording_type_,
             room_id,
+            section_id,
+            term_id,
     ):
-        self.section_id = section_id
-        self.term_id = term_id
+        self.course_display_name = course_display_name
         self.instructor_uids = instructor_uids
         self.kaltura_schedule_id = kaltura_schedule_id
         self.meeting_days = meeting_days
@@ -80,13 +81,15 @@ class Scheduled(db.Model):
         self.publish_type = publish_type_
         self.recording_type = recording_type_
         self.room_id = room_id
+        self.section_id = section_id
+        self.term_id = term_id
 
     def __repr__(self):
         return f"""<Scheduled
                     id={self.id},
-                    section_id={self.section_id},
-                    term_id={self.term_id},
                     alerts={', '.join(self.alerts or [])},
+                    course_display_name={self.course_display_name},
+                    created_at={self.created_at},
                     instructor_uids={', '.join(self.instructor_uids)},
                     kaltura_schedule_id={self.kaltura_schedule_id}
                     meeting_days={self.meeting_days},
@@ -97,14 +100,14 @@ class Scheduled(db.Model):
                     publish_type={self.publish_type},
                     recording_type={self.recording_type},
                     room_id={self.room_id},
-                    created_at={self.created_at}>
+                    section_id={self.section_id},
+                    term_id={self.term_id}>
                 """
 
     @classmethod
     def create(
             cls,
-            section_id,
-            term_id,
+            course_display_name,
             instructor_uids,
             kaltura_schedule_id,
             meeting_days,
@@ -115,8 +118,11 @@ class Scheduled(db.Model):
             publish_type_,
             recording_type_,
             room_id,
+            section_id,
+            term_id,
     ):
         scheduled = cls(
+            course_display_name=course_display_name,
             instructor_uids=instructor_uids,
             kaltura_schedule_id=kaltura_schedule_id,
             meeting_days=meeting_days,
@@ -180,6 +186,7 @@ class Scheduled(db.Model):
         return {
             'id': self.id,
             'alerts': self.alerts or [],
+            'courseDisplayName': self.course_display_name,
             'createdAt': to_isoformat(self.created_at),
             'instructorUids': self.instructor_uids,
             'kalturaScheduleId': self.kaltura_schedule_id,

--- a/scripts/db/migrate/2021/20210924-DIABLO-654/add_course_display_name_column.sql
+++ b/scripts/db/migrate/2021/20210924-DIABLO-654/add_course_display_name_column.sql
@@ -1,0 +1,36 @@
+/**
+ * Copyright ©2021. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+BEGIN;
+
+    ALTER TABLE scheduled ADD COLUMN course_display_name VARCHAR(255);
+    UPDATE scheduled SET course_display_name = 'term_id:' || term_id || ' section_id:' || section_id;
+    ALTER TABLE scheduled ALTER COLUMN course_display_name SET NOT NULL;
+
+    ALTER TABLE approvals ADD COLUMN course_display_name VARCHAR(255);
+    UPDATE approvals SET course_display_name = 'term_id:' || term_id || ' section_id:' || section_id;
+    ALTER TABLE approvals ALTER COLUMN course_display_name SET NOT NULL;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -116,14 +116,15 @@ ALTER TABLE ONLY admin_users
 CREATE TABLE approvals (
     id SERIAL PRIMARY KEY,
     approved_by_uid VARCHAR(80) NOT NULL,
-    section_id INTEGER NOT NULL,
-    term_id INTEGER NOT NULL,
     approver_type approver_types,
+    course_display_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE,
     publish_type publish_types NOT NULL,
     recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    deleted_at TIMESTAMP WITH TIME ZONE
+    section_id INTEGER NOT NULL,
+    term_id INTEGER NOT NULL
 );
 ALTER TABLE approvals OWNER TO diablo;
 CREATE UNIQUE INDEX approvals_unique_idx ON approvals (approved_by_uid, section_id, term_id) WHERE deleted_at IS NULL;
@@ -337,9 +338,10 @@ CREATE INDEX rooms_location_idx ON rooms USING btree (location);
 
 CREATE TABLE scheduled (
     id SERIAL PRIMARY KEY,
-    section_id INTEGER NOT NULL,
-    term_id INTEGER NOT NULL,
     alerts email_template_types[],
+    course_display_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE,
     instructor_uids VARCHAR(80)[] NOT NULL,
     kaltura_schedule_id INTEGER NOT NULL,
     meeting_days VARCHAR(80) NOT NULL,
@@ -350,8 +352,8 @@ CREATE TABLE scheduled (
     publish_type publish_types NOT NULL,
     recording_type recording_types NOT NULL,
     room_id INTEGER NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    deleted_at TIMESTAMP WITH TIME ZONE
+    section_id INTEGER NOT NULL,
+    term_id INTEGER NOT NULL
 );
 ALTER TABLE scheduled OWNER TO diablo;
 CREATE UNIQUE INDEX scheduled_unique_idx ON scheduled (section_id, term_id) WHERE deleted_at IS NULL;

--- a/tests/test_api/api_test_utils.py
+++ b/tests/test_api/api_test_utils.py
@@ -92,6 +92,7 @@ def mock_scheduled(
 ):
     meeting = meeting or get_eligible_meeting(section_id=section_id, term_id=term_id)
     Scheduled.create(
+        course_display_name=f'term_id:{term_id} section_id:{section_id}',
         instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
         kaltura_schedule_id=random.randint(1, 10),
         meeting_days=override_days or meeting['days'],

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -160,9 +160,11 @@ class TestApprove:
             assert len(approvals_) == 2
 
             assert approvals_[0]['approvedBy'] == instructor_uids[0]
+            assert approvals_[0]['courseDisplayName'] == api_json['label']
             assert approvals_[0]['publishType'] == 'kaltura_my_media'
 
             assert approvals_[1]['approvedBy'] == instructor_uids[1]
+            assert approvals_[1]['courseDisplayName'] == api_json['label']
             assert approvals_[1]['publishType'] == 'kaltura_media_gallery'
             assert approvals_[1]['recordingType'] == 'presentation_audio'
             assert approvals_[1]['recordingTypeName'] == 'Presentation and Audio'
@@ -183,6 +185,10 @@ class TestApprove:
             std_commit(allow_test_environment=True)
             assert api_json['hasNecessaryApprovals'] is True
             assert api_json['scheduled'] is None
+
+            approvals = api_json['approvals']
+            assert len(approvals) == 1
+            assert approvals[0]['courseDisplayName'] == api_json['label']
 
     def test_has_necessary_approvals_when_cross_listed(self, client, fake_auth):
         """If section X and Y are cross-listed then hasNecessaryApprovals is false until the Y instructor approves."""
@@ -260,6 +266,7 @@ class TestGetCourse:
             Approval.create(
                 approved_by_uid=approved_by_uid,
                 approver_type_='instructor',
+                course_display_name=f'term_id:{self.term_id} section_id:{section_1_id}',
                 publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
                 room_id=room_id,
@@ -580,6 +587,7 @@ class TestGetCourses:
                     Approval.create(
                         approved_by_uid=admin_uid,
                         approver_type_='admin',
+                        course_display_name=f'term_id:{self.term_id} section_id:{section_id}',
                         publish_type_='kaltura_my_media',
                         recording_type_='presentation_audio',
                         room_id=Room.get_room_id(section_id=section_id, term_id=self.term_id),
@@ -783,6 +791,7 @@ class TestCoursesChanges:
             assert meeting['days'] != obsolete_meeting_days
 
             Scheduled.create(
+                course_display_name=f'term_id:{self.term_id} section_id:{section_1_id}',
                 instructor_uids=get_instructor_uids(term_id=self.term_id, section_id=section_1_id),
                 kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=obsolete_meeting_days,
@@ -815,6 +824,7 @@ class TestCoursesChanges:
             assert meeting['endDate'] != obsolete_meeting_end_date
 
             Scheduled.create(
+                course_display_name=f'term_id:{self.term_id} section_id:{section_1_id}',
                 instructor_uids=get_instructor_uids(term_id=self.term_id, section_id=section_1_id),
                 kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting['days'],
@@ -848,6 +858,7 @@ class TestCoursesChanges:
             assert len(instructor_uids) > 1
             scheduled_with_uid = instructor_uids[0]
             Scheduled.create(
+                course_display_name=f'term_id:{self.term_id} section_id:{section_1_id}',
                 instructor_uids=[scheduled_with_uid],
                 kaltura_schedule_id=random.randint(1, 10),
                 meeting_days=meeting['days'],
@@ -1166,6 +1177,7 @@ def _create_approval(section_id, term_id):
     Approval.create(
         approved_by_uid=get_instructor_uids(section_id=section_id, term_id=term_id)[0],
         approver_type_='instructor',
+        course_display_name=f'term_id:{term_id} section_id:{section_id}',
         publish_type_='kaltura_my_media',
         recording_type_='presentation_audio',
         room_id=Room.get_room_id(section_id=section_id, term_id=term_id),

--- a/tests/test_jobs/test_admin_emails_job.py
+++ b/tests/test_jobs/test_admin_emails_job.py
@@ -103,6 +103,7 @@ class TestAdminEmailsJob:
                 approval = Approval.create(
                     approved_by_uid=approved_by_uid,
                     approver_type_='instructor',
+                    course_display_name=f'term_id:{term_id} section_id:{section_id}',
                     publish_type_='kaltura_media_gallery',
                     recording_type_='presenter_audio',
                     room_id=scheduled_in_room.id,
@@ -111,6 +112,7 @@ class TestAdminEmailsJob:
                 )
                 meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
                 Scheduled.create(
+                    course_display_name=f'term_id:{term_id} section_id:{section_id}',
                     instructor_uids=get_instructor_uids(term_id=term_id, section_id=section_id),
                     kaltura_schedule_id=random.randint(1, 10),
                     meeting_days=meeting['days'],
@@ -146,6 +148,7 @@ class TestAdminEmailsJob:
                 approval = Approval.create(
                     approved_by_uid=instructor_1_uid,
                     approver_type_='instructor',
+                    course_display_name=f'term_id:{term_id} section_id:{section_id}',
                     publish_type_='kaltura_my_media',
                     recording_type_='presenter_audio',
                     room_id=room_id,
@@ -155,6 +158,7 @@ class TestAdminEmailsJob:
                 # Uh oh! Only one of them has been scheduled.
                 meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
                 Scheduled.create(
+                    course_display_name=f'term_id:{term_id} section_id:{section_id}',
                     instructor_uids=[instructor_1_uid],
                     kaltura_schedule_id=random.randint(1, 10),
                     meeting_days=meeting['days'],
@@ -193,6 +197,7 @@ class TestAdminEmailsJob:
                 approval = Approval.create(
                     approved_by_uid=instructor_uid,
                     approver_type_='instructor',
+                    course_display_name=f'term_id:{term_id} section_id:{section_id}',
                     publish_type_='kaltura_my_media',
                     recording_type_='presenter_audio',
                     room_id=room_id,
@@ -202,6 +207,7 @@ class TestAdminEmailsJob:
                 # Uh oh! Only one of them has been scheduled.
                 meeting = get_eligible_meeting(section_id=section_id, term_id=term_id)
                 Scheduled.create(
+                    course_display_name=f'{section_id}:{term_id}',
                     instructor_uids=[instructor_uid],
                     kaltura_schedule_id=random.randint(1, 10),
                     meeting_days=meeting['days'],

--- a/tests/test_jobs/test_kaltura_job.py
+++ b/tests/test_jobs/test_kaltura_job.py
@@ -73,6 +73,7 @@ class TestKalturaJob:
                 Approval.create(
                     approved_by_uid=instructors[0]['uid'],
                     approver_type_='instructor',
+                    course_display_name=course['label'],
                     publish_type_='kaltura_my_media',
                     recording_type_='presentation_audio',
                     room_id=room_id,
@@ -90,6 +91,7 @@ class TestKalturaJob:
             final_approval = Approval.create(
                 approved_by_uid=instructors[1]['uid'],
                 approver_type_='instructor',
+                course_display_name=course['label'],
                 publish_type_='kaltura_media_gallery',
                 recording_type_='presenter_presentation_audio',
                 room_id=room_id,
@@ -140,6 +142,7 @@ class TestKalturaJob:
             Approval.create(
                 approved_by_uid=admin_uid,
                 approver_type_='admin',
+                course_display_name=course['label'],
                 publish_type_='kaltura_my_media',
                 recording_type_='presentation_audio',
                 room_id=Room.find_room('Barker 101').id,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-677

We'll use `course_display_name` when course is cancelled and we have no SIS data per section_id. (Release instructions updated.)

*Note:* The reordering of args in certain methods is only alpha sort. 