### PR TITLE
DIABLO-675, blackouts job uses shared util 'represents_recording_series' to skip delete of parent event

### DIFF
--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -31,7 +31,7 @@ from diablo import cachify, skip_when_pytest
 from diablo.lib.berkeley import get_first_matching_datetime_of_term, get_recording_end_date, get_recording_start_date, \
     term_name_for_sis_id
 from diablo.lib.kaltura_util import get_classification_name, get_recurrence_name, get_series_description, \
-    get_status_name
+    get_status_name, represents_recording_series
 from diablo.lib.util import default_timezone, epoch_time_to_isoformat, format_days
 from flask import current_app as app
 from KalturaClient import KalturaClient, KalturaConfiguration
@@ -445,7 +445,7 @@ def _events_to_api_json(events):
     recurring_events = []
     miscellanea = []
     for event in [_event_to_json(event) for event in events]:
-        if event.get('recurrenceType', '').lower() == 'recurring':
+        if represents_recording_series(event):
             recurring_events.append(event)
         else:
             miscellanea.append(event)

--- a/diablo/jobs/blackouts_job.py
+++ b/diablo/jobs/blackouts_job.py
@@ -24,10 +24,10 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 from diablo.externals.kaltura import CREATED_BY_DIABLO_TAG, Kaltura
 from diablo.jobs.base_job import BaseJob
+from diablo.lib.kaltura_util import represents_recording_series
 from diablo.lib.util import utc_now
 from diablo.models.blackout import Blackout
 from flask import current_app as app
-from KalturaClient.Plugins.Schedule import KalturaScheduleEventRecurrenceType
 
 
 class BlackoutsJob(BaseJob):
@@ -42,7 +42,7 @@ class BlackoutsJob(BaseJob):
                 events = kaltura.get_events_in_date_range(end_date=blackout.end_date, start_date=blackout.start_date)
                 for event in events:
                     created_by_diablo = CREATED_BY_DIABLO_TAG in event['tags']
-                    if created_by_diablo and event['recurrenceType'] != KalturaScheduleEventRecurrenceType.RECURRING:
+                    if created_by_diablo and not represents_recording_series(event):
                         kaltura.delete(event['id'])
                         app.logger.info(f"'Event {event['summary']} deleted per {blackout}.")
 

--- a/diablo/lib/kaltura_util.py
+++ b/diablo/lib/kaltura_util.py
@@ -58,3 +58,7 @@ def get_series_description(course_label, instructors, term_name):
     summary = f'{course_label} ({term_name}) is taught by {readable_join(names)}.'
     legalese = f"Copyright ©{datetime.strftime(datetime.now(), '%Y')} UC Regents; all rights reserved."
     return f'{summary} {legalese}'
+
+
+def represents_recording_series(event):
+    return event.get('recurrenceType', '').lower() == 'recurring'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/DIABLO-675

The API returns name of recurrenceType, not int type. Use same logic used elsewhere.