### PR TITLE
DIABLO-755, upgrade to Flask/Werkzeug 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 canvasapi==2.2.0
 click==8.1.3
 decorator==5.1.1
-Flask-Caching==2.0.0
+Flask-Caching==2.0.1
 Flask-Cors==3.0.10
-Flask-Login==0.6.1
+Flask-Login==0.6.2
 Flask-SQLAlchemy==2.5.1
-Flask==2.1.2
+Flask==2.2.2
 KalturaApiClient==18.12.0
 ldap3==2.7
 pprintpp==0.4.0
@@ -14,13 +14,13 @@ python-dateutil==2.8.2
 requests==2.28.1
 schedule==1.1.0
 simplejson==3.17.6
-SQLAlchemy==1.4.40
-Werkzeug==2.1.2
+SQLAlchemy==1.4.41
+Werkzeug==2.2.2
 https://github.com/python-cas/python-cas/archive/master.zip
 
 # For testing
 moto==3.1.16
-pytest==7.1.2
+pytest==7.1.3
 pytest-flask==1.2.0
 pytz==2022.2.1
 responses==0.21.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ import os
 
 from diablo import cache
 import diablo.factory
+from flask_login import logout_user
 from moto import mock_sts
 import pytest
 from tests.util import override_config
@@ -87,6 +88,11 @@ def db(app):
     _db = development_db.load()
 
     return _db
+
+
+@pytest.fixture(autouse=True, scope='function')
+def logout():
+    logout_user()
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-755

I think I figured this out.  We need explicit `logout_user ` between tests. Let's see what Travis thinks.