### PR TITLE
DIABLO-771, keep APRX info out of _all_ Kaltura series descriptions

### DIFF
--- a/diablo/externals/kaltura.py
+++ b/diablo/externals/kaltura.py
@@ -33,7 +33,6 @@ from diablo.lib.berkeley import get_first_matching_datetime_of_term, get_recordi
 from diablo.lib.kaltura_util import get_classification_name, get_recurrence_name, get_series_description, \
     get_status_name, represents_recording_series
 from diablo.lib.util import default_timezone, epoch_time_to_isoformat, format_days
-from diablo.models.sis_section import AUTHORIZED_INSTRUCTOR_ROLE_CODES
 from flask import current_app as app
 from KalturaClient import KalturaClient, KalturaConfiguration
 from KalturaClient.Plugins.Core import KalturaBaseEntry, KalturaCategoryEntry, KalturaCategoryEntryFilter, \
@@ -351,7 +350,7 @@ class Kaltura:
         )
         description = get_series_description(
             course_label=course_label,
-            instructors=list(filter(lambda i: i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES, instructors)),
+            instructors=instructors,
             term_name=term_name,
         )
         base_entry = self._create_kaltura_base_entry(

--- a/diablo/lib/kaltura_util.py
+++ b/diablo/lib/kaltura_util.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime
 
 from diablo.lib.util import readable_join
+from diablo.models.sis_section import AUTHORIZED_INSTRUCTOR_ROLE_CODES
 from KalturaClient.Plugins.Schedule import KalturaScheduleEventClassificationType, KalturaScheduleEventRecurrenceType, \
     KalturaScheduleEventStatus
 
@@ -54,7 +55,8 @@ def get_status_name(status_type):
 
 
 def get_series_description(course_label, instructors, term_name):
-    names = [instructor['name'] for instructor in instructors]
+    instructors_who_teach = list(filter(lambda i: i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES, instructors))
+    names = [instructor['name'] for instructor in instructors_who_teach]
     summary = f'{course_label} ({term_name}) is taught by {readable_join(names)}.'
     legalese = f"Copyright ©{datetime.strftime(datetime.now(), '%Y')} UC Regents; all rights reserved."
     return f'{summary} {legalese}'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-771

Previous PR fixed only one usage of `get_series_descriptions`. This covers 'em all.