### PR TITLE
[QA] DIABLO-780, db migrate script: remove_aprx_from_scheduled_instructor_uids.sql

### DIFF
--- a/scripts/db/migrate/2022/20221216-DIABLO-780/remove_aprx_from_scheduled_instructor_uids.sql
+++ b/scripts/db/migrate/2022/20221216-DIABLO-780/remove_aprx_from_scheduled_instructor_uids.sql
@@ -1,0 +1,39 @@
+/**
+ * Copyright ©2022. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+DO
+$BODY$
+DECLARE
+    aprx_uids json := '[1061965, 1581216, 161427, 1617491, 1629731, 1752603, 1753191, 1753681, 1753722, 1753918]';
+    aprx_uid json;
+BEGIN
+  FOR aprx_uid IN SELECT * FROM json_array_elements(aprx_uids)
+  LOOP
+    UPDATE scheduled
+      SET instructor_uids = array_remove(instructor_uids, aprx_uid::VARCHAR)
+      WHERE term_id = 2232 AND section_id IN (30715, 22183, 30215, 30388);
+  END LOOP;
+END;
+$BODY$ language plpgsql


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-780

APRX UIDs do not belong in `scheduled`.