### PR TITLE
DIABLO-844 Re-restrict recording placement to two options

### DIFF
--- a/diablo/models/course_preference.py
+++ b/diablo/models/course_preference.py
@@ -50,10 +50,11 @@ recording_type = ENUM(
     create_type=False,
 )
 
+# The "kaltura_media_gallery_moderated" publish type exists in the database and is referenced in back-end code, but is not currently
+# offered through the UI owing to Kaltura API limitations.
 
 NAMES_PER_PUBLISH_TYPE = {
-    'kaltura_media_gallery': 'Publish Automatically to Course Site',
-    'kaltura_media_gallery_moderated': 'Publish to Pending Tab in Course Site',
+    'kaltura_media_gallery': 'Publish to Course Site',
     'kaltura_my_media': 'Publish to My Media',
 }
 

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -640,8 +640,7 @@ export default {
       course: undefined,
       courseDisplayTitle: null,
       displayLabels: {
-        'kaltura_media_gallery': 'Publish automatically to the Media Gallery (all members of the bCourses site will have access)',
-        'kaltura_media_gallery_moderated': 'Publish to Pending tab (Teacher/TA/Designer members of the bCourses site can approve recordings for viewing)',
+        'kaltura_media_gallery': 'Publish to the Media Gallery (all members of the bCourses site will have access)',
         'kaltura_my_media': 'Publish to My Media (I will decide if and how I want to share)',
         'presenter_presentation_audio': 'Camera Without Operator',
         'presenter_presentation_audio_with_operator': `Camera With Operator ($${this.$config.courseCapturePremiumCost} fee)`

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -629,7 +629,7 @@ class TestUpdatePublishType:
             expected_status_code=401,
         )
 
-    def test_canvas_site_ids_required_unmoderated(self, client, fake_auth):
+    def test_canvas_site_ids_required(self, client, fake_auth):
         # kaltura_media_gallery setting requires Canvas site IDs.
         instructor_uids = get_instructor_uids(section_id=section_1_id, term_id=self.term_id)
         fake_auth.login(instructor_uids[0])
@@ -641,21 +641,6 @@ class TestUpdatePublishType:
             term_id=self.term_id,
             section_id=section_1_id,
             publish_type='kaltura_media_gallery',
-            expected_status_code=400,
-        )
-
-    def test_canvas_site_ids_required_moderated(self, client, fake_auth):
-        # kaltura_media_gallery_moderated setting requires Canvas site IDs.
-        instructor_uids = get_instructor_uids(section_id=section_1_id, term_id=self.term_id)
-        fake_auth.login(instructor_uids[0])
-
-        course = SisSection.get_course(section_id=section_1_id, term_id=self.term_id)
-        assert course['publishType'] == 'kaltura_my_media'
-        self._api_publish_type_update(
-            client,
-            term_id=self.term_id,
-            section_id=section_1_id,
-            publish_type='kaltura_media_gallery_moderated',
             expected_status_code=400,
         )
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-844

Revert the revert. In an effort to minimize churn, a certain amount of moderation-related code remains on the back end but is not available for selection in the UI. 