### PR TITLE
DIABLO-1090 Remove user-editable name from email templates

### DIFF
--- a/diablo/api/email_controller.py
+++ b/diablo/api/email_controller.py
@@ -71,16 +71,17 @@ def get_template_codes():
 def create_template():
     params = request.get_json()
     template_type = params.get('templateType')
-    name = params.get('name')
     subject_line = params.get('subjectLine')
     message = params.get('message')
 
-    if None in [template_type, name, subject_line, message]:
+    if None in [template_type, subject_line, message]:
         raise BadRequestError('Required parameters are missing.')
+
+    if EmailTemplate.get_template_by_type(template_type):
+        raise BadRequestError('Template type already exists.')
 
     email_template = EmailTemplate.create(
         template_type=template_type,
-        name=name,
         subject_line=subject_line,
         message=message,
     )
@@ -127,17 +128,15 @@ def update_template():
     email_template = EmailTemplate.get_template(template_id) if template_id else None
     if email_template:
         template_type = params.get('templateType')
-        name = params.get('name')
         subject_line = params.get('subjectLine')
         message = params.get('message')
 
-        if None in [template_type, name, subject_line, message]:
+        if None in [template_type, subject_line, message]:
             raise BadRequestError('Required parameters are missing.')
 
         email_template = EmailTemplate.update(
             template_id=template_id,
             template_type=template_type,
-            name=name,
             subject_line=subject_line,
             message=message,
         )

--- a/diablo/models/development_db.py
+++ b/diablo/models/development_db.py
@@ -108,73 +108,61 @@ def _create_blackouts():
 def _create_email_templates():
     EmailTemplate.create(
         template_type='admin_operator_requested',
-        name='Admin alert: operator requested',
         subject_line='Admin alert: operator requested',
         message='Operator requested for class for class <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='changes_confirmed',
-        name='Changes confirmed',
         subject_line='Changes confirmed',
         message='Changes confirmed for class <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='instructors_added',
-        name='Instructor(s) added to class',
         subject_line='Instructor(s) added to class',
         message='Instructor(s) added to class <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='instructors_removed',
-        name='Instructor(s) removed from class',
         subject_line='Instructor(s) removed from class',
         message='Instructor(s) removed from class <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='multiple_meeting_pattern_change',
-        name='Multiple meeting pattern change',
         subject_line='Marvelous multiple meeting patterns',
         message='<code>course.name</code> had a complicated change, better go check it out in Diablo.',
     )
     EmailTemplate.create(
         template_type='new_class_scheduled',
-        name='New class scheduled',
         subject_line='New class scheduled: <code>course.name</code>',
         message='Intensely.',
     )
     EmailTemplate.create(
         template_type='no_longer_scheduled',
-        name='Class no longer scheduled',
         subject_line='Class no longer scheduled',
         message='Class no longer scheduled: <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='opted_out',
-        name='Opted out',
         subject_line='Opted out',
         message='Class opted out: <code>course.name</code>',
     )
     EmailTemplate.create(
         template_type='remind_scheduled',
-        name='Blessed are those who are scheduled',
         subject_line='Did you remember??',
         message='You are scheduled, <code>recipient.name</code>!\n<code>courseList</code>',
     )
     EmailTemplate.create(
         template_type='room_change_no_longer_eligible',
-        name='Room change: no longer eligible',
         subject_line='Room change alert',
         message='<code>course.name</code> has changed to a new, ineligible room: <code>course.room</code>',
     )
     EmailTemplate.create(
         template_type='schedule_change',
-        name='Schedule change',
         subject_line='Schedule change alert',
         message='<code>course.name</code> has changed to a new room and/or schedule: <code>course.room</code>',
     )
     EmailTemplate.create(
         template_type='semester_start',
-        name='Semester start',
         subject_line="It's a new semester, tally ho!",
         message="Well, then let's introduce ourselves. I'm <code>recipient.name</code> and these are my courses:\n<code>courseList</code>",
     )

--- a/diablo/models/email_template.py
+++ b/diablo/models/email_template.py
@@ -51,19 +51,16 @@ class EmailTemplate(Base):
 
     id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
     template_type = db.Column(email_template_type, nullable=False)
-    name = db.Column(db.String(255), nullable=False, unique=True)
     subject_line = db.Column(db.String(255), nullable=False)
     message = db.Column(db.Text, nullable=False)
 
     def __init__(
             self,
             template_type,
-            name,
             subject_line,
             message,
     ):
         self.template_type = template_type
-        self.name = name
         self.subject_line = subject_line
         self.message = message
 
@@ -71,16 +68,14 @@ class EmailTemplate(Base):
         return f"""<EmailTemplate
                     id={self.id},
                     template_type={self.template_type},
-                    name={self.name},
                     subject_line={self.subject_line}
                     message={self.message}>
                 """
 
     @classmethod
-    def create(cls, template_type, name, subject_line, message):
+    def create(cls, template_type, subject_line, message):
         email_template = cls(
             template_type=template_type,
-            name=name,
             subject_line=subject_line,
             message=message,
         )
@@ -102,18 +97,14 @@ class EmailTemplate(Base):
         return cls.query.filter_by(template_type=template_type).first()
 
     @classmethod
-    def get_all_templates_names(cls):
-        return cls.query.with_entities(cls.id, cls.name).order_by(cls.name).all()
-
-    @classmethod
     def all_templates(cls):
-        return cls.query.order_by(cls.name).all()
+        display_names = cls.get_template_type_options()
+        return sorted(cls.query.all(), key=lambda t: display_names.get(t.template_type))
 
     @classmethod
-    def update(cls, template_id, template_type, name, subject_line, message):
+    def update(cls, template_id, template_type, subject_line, message):
         email_template = cls.query.filter_by(id=template_id).first()
         email_template.template_type = template_type
-        email_template.name = name
         email_template.subject_line = subject_line
         email_template.message = message
         db.session.add(email_template)
@@ -142,7 +133,6 @@ class EmailTemplate(Base):
             'id': self.id,
             'templateType': self.template_type,
             'typeName': self.get_template_type_options()[self.template_type],
-            'name': self.name,
             'subjectLine': self.subject_line,
             'message': self.message,
             'createdAt': to_isoformat(self.created_at),

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -48,7 +48,7 @@ ALTER TABLE IF EXISTS ONLY public.blackouts DROP CONSTRAINT IF EXISTS blackouts_
 ALTER TABLE IF EXISTS ONLY public.canvas_course_sites DROP CONSTRAINT IF EXISTS canvas_course_sites_pkey;
 ALTER TABLE IF EXISTS ONLY public.course_preferences DROP CONSTRAINT IF EXISTS course_preferences_pkey;
 ALTER TABLE IF EXISTS ONLY public.cross_listings DROP CONSTRAINT IF EXISTS cross_listings_pkey;
-ALTER TABLE IF EXISTS ONLY public.email_templates DROP CONSTRAINT IF EXISTS email_templates_name_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.email_templates DROP CONSTRAINT IF EXISTS email_templates_type_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.email_templates DROP CONSTRAINT IF EXISTS email_templates_pkey;
 ALTER TABLE IF EXISTS ONLY public.instructors DROP CONSTRAINT IF EXISTS instructors_pkey;
 ALTER TABLE IF EXISTS ONLY public.jobs DROP CONSTRAINT IF EXISTS jobs_key_unique_constraint;

--- a/scripts/db/migrate/2025/20250521-DIABLO-1090/drop_email_template_name.sql
+++ b/scripts/db/migrate/2025/20250521-DIABLO-1090/drop_email_template_name.sql
@@ -1,0 +1,27 @@
+/**
+ * Copyright ©2025. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+ALTER TABLE email_templates DROP COLUMN name;
+ALTER TABLE email_templates ADD CONSTRAINT email_templates_type_unique_constraint UNIQUE (template_type);

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -168,7 +168,6 @@ ALTER TABLE cross_listings ADD CONSTRAINT cross_listings_pkey PRIMARY KEY (secti
 CREATE TABLE email_templates (
     id INTEGER NOT NULL,
     template_type email_template_types NOT NULL,
-    name VARCHAR(255) NOT NULL,
     message TEXT NOT NULL,
     subject_line VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -187,7 +186,7 @@ ALTER TABLE ONLY email_templates ALTER COLUMN id SET DEFAULT nextval('email_temp
 ALTER TABLE ONLY email_templates
     ADD CONSTRAINT email_templates_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY email_templates
-    ADD CONSTRAINT email_templates_name_unique_constraint UNIQUE (name);
+    ADD CONSTRAINT email_templates_type_unique_constraint UNIQUE (template_type);
 
 --
 

--- a/src/api/email.ts
+++ b/src/api/email.ts
@@ -1,10 +1,9 @@
 import axios from 'axios'
 import {getApiBaseUrl} from '@/api/api-utils'
 
-export function createEmailTemplate(templateType, name, subjectLine, message) {
+export function createEmailTemplate(templateType, subjectLine, message) {
   return axios.post(`${getApiBaseUrl()}/api/email/template/create`, {
     templateType,
-    name,
     subjectLine,
     message
   })
@@ -43,11 +42,10 @@ export function sendTestEmail(templateId) {
     .then(response => response.data)
 }
 
-export function updateEmailTemplate(templateId, templateType, name, subjectLine, message) {
+export function updateEmailTemplate(templateId, templateType, subjectLine, message) {
   return axios.post(`${getApiBaseUrl()}/api/email/template/update`, {
     templateId,
     templateType,
-    name,
     subjectLine,
     message
   })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,7 @@ export function getCourseCodes(course) {
 
 export function getSelectOptionsFromObject(obj: any, isDisabled: Function) {
   const options: Array<any> = []
-  each(obj, (text, value) => options.push({text, value, disabled: isDisabled(value)}))
+  each(obj, (text, value) => options.push({text, value, props: {disabled: isDisabled(value)}}))
   return options
 }
 

--- a/src/views/email/EditEmailTemplate.vue
+++ b/src/views/email/EditEmailTemplate.vue
@@ -11,20 +11,6 @@
       <v-row class="pl-4">
         <v-col cols="12" sm="8">
           <v-text-field
-            id="input-template-name"
-            v-model="name"
-            aria-required="true"
-            label="Template Name"
-            maxlength="255"
-            :rules="[s => !!s || 'Required']"
-          >
-          </v-text-field>
-        </v-col>
-        <v-spacer></v-spacer>
-      </v-row>
-      <v-row class="pl-4">
-        <v-col cols="12" sm="8">
-          <v-text-field
             id="input-template-subject-line"
             v-model="subjectLine"
             aria-required="true"
@@ -89,7 +75,6 @@ import {useContextStore} from '@/stores/context'
 
 const contextStore = useContextStore()
 const message = ref('')
-const name = ref()
 const pageTitle = ref('')
 const route = useRoute()
 const router = useRouter()
@@ -99,7 +84,7 @@ const templateType = ref()
 const typeName = ref()
 
 const disableSave = computed(() => {
-  return !trim(subjectLine.value) || !trim(name.value) || !stripHtmlAndTrim(message.value)
+  return !trim(subjectLine.value) || !stripHtmlAndTrim(message.value)
 })
 
 onMounted(() => {
@@ -112,7 +97,6 @@ onMounted(() => {
     contextStore.loadingComplete(`${pageTitle.value} '${typeName.value}'`)
   } else {
     getEmailTemplate(templateId.value).then(data => {
-      name.value = data.name
       subjectLine.value = data.subjectLine
       message.value = data.message
       templateType.value = data.templateType
@@ -135,9 +119,9 @@ const createTemplate = () => {
   if (disableSave.value) {
     contextStore.snackbarReportError('You must complete the required form fields.')
   } else if (templateId.value) {
-    updateEmailTemplate(templateId.value, templateType.value, name.value, subjectLine.value, message.value).then(() => done('updated'))
+    updateEmailTemplate(templateId.value, templateType.value, subjectLine.value, message.value).then(() => done('updated'))
   } else {
-    createEmailTemplate(templateType.value, name.value, subjectLine.value, message.value).then(() => done('created'))
+    createEmailTemplate(templateType.value, subjectLine.value, message.value).then(() => done('created'))
   }
 }
 </script>

--- a/src/views/email/EmailTemplates.vue
+++ b/src/views/email/EmailTemplates.vue
@@ -71,20 +71,17 @@
               </td>
             </tr>
             <tr v-for="template in items" :key="template.id">
-              <td>
+              <td :id="`template-${template.id}-type-name`">
                 <router-link
                   :id="`template-${template.id}`"
                   class="text-anchor"
                   :to="`/email/template/edit/${template.id}`"
                 >
-                  {{ template.name }}
+                  {{ template.typeName }}
                 </router-link>
               </td>
               <td :id="`template-${template.id}-subject-line`" class="w-50">
                 {{ template.subjectLine }}
-              </td>
-              <td :id="`template-${template.id}-type-name`">
-                {{ template.typeName }}
               </td>
               <td :id="`template-${template.id}-createdAt`" class="text-no-wrap">
                 {{ DateTime.fromISO(template.createdAt, DateTime.DATE_MED) }}
@@ -130,9 +127,8 @@ import {useContextStore} from '@/stores/context'
 
 const contextStore = useContextStore()
 const headers = [
-  {title: 'Name', value: 'name'},
-  {title: 'Subject Line', value: 'subjectLine'},
   {title: 'Type', value: 'typeName'},
+  {title: 'Subject Line', value: 'subjectLine'},
   {title: 'Created', value: 'createdAt'},
   {title: 'Test', value: 'test', class: 'pl-5 pr-0 mr-0'},
   {title: 'Delete', value: 'delete', class: 'pl-5 pr-0 mr-0'}

--- a/tests/test_api/test_email_controller.py
+++ b/tests/test_api/test_email_controller.py
@@ -62,7 +62,7 @@ class TestGetAllEmailTemplates:
         """Admin user has access."""
         email_templates = self._api_all_email_templates(client)
         assert len(email_templates) > 1
-        for key in ['id', 'templateType', 'name', 'subjectLine', 'message']:
+        for key in ['id', 'templateType', 'subjectLine', 'message']:
             assert key in email_templates[0]
 
 
@@ -89,11 +89,11 @@ class TestGetEmailTemplate:
 
     def test_get_email_template(self, client, admin_session):
         """Admin user has access to email_template data."""
-        email_template = next((t for t in EmailTemplate.all_templates() if t.name == 'Instructor(s) removed from class'), None)
+        email_template = next((t for t in EmailTemplate.all_templates() if t.template_type == 'instructors_removed'), None)
         assert email_template
         api_json = self._api_email_template(client, email_template.id)
         assert api_json['id'] == email_template.id
-        assert api_json['name'] == 'Instructor(s) removed from class'
+        assert api_json['templateType'] == 'instructors_removed'
 
 
 class TestUpdateEmailTemplate:
@@ -104,7 +104,6 @@ class TestUpdateEmailTemplate:
             client,
             email_template_id,
             template_type,
-            name,
             subject_line,
             message,
             expected_status_code=200,
@@ -114,7 +113,6 @@ class TestUpdateEmailTemplate:
             data=json.dumps({
                 'templateId': email_template_id,
                 'templateType': template_type,
-                'name': name,
                 'subjectLine': subject_line,
                 'message': message,
             }),
@@ -129,7 +127,6 @@ class TestUpdateEmailTemplate:
             client,
             email_template_id=1,
             template_type='changes_confirmed',
-            name='Captain who?',
             subject_line='Captain Howdy.',
             message="Who's Captain Howdy?",
             expected_status_code=401,
@@ -141,7 +138,6 @@ class TestUpdateEmailTemplate:
             client,
             email_template_id=1,
             template_type='changes_confirmed',
-            name='Captain who?',
             subject_line='Captain Howdy.',
             message="Who's Captain Howdy?",
             expected_status_code=401,
@@ -153,7 +149,6 @@ class TestUpdateEmailTemplate:
             client,
             email_template_id=999999999,
             template_type='changes_confirmed',
-            name='Father Dyer',
             subject_line='My idea of Heaven',
             message='My idea of Heaven is a solid white nightclub with me as a headliner for all eternity, and they love me!',
             expected_status_code=404,
@@ -163,17 +158,16 @@ class TestUpdateEmailTemplate:
         """Admin user has access."""
         email_template_id = 1
         email_template = EmailTemplate.get_template(email_template_id)
-        name = f'{email_template.name} (modified)'
+        subject_line = f'{email_template.subject_line} (modified)'
         email_template = self._api_update_email_template(
             client,
             email_template_id=email_template.id,
             template_type=email_template.template_type,
-            name=name,
-            subject_line=email_template.subject_line,
+            subject_line=subject_line,
             message=email_template.message,
         )
         assert len(email_template)
-        assert email_template['name'] == name
+        assert email_template['subjectLine'] == subject_line
 
 
 class TestCreateEmailTemplate:
@@ -183,7 +177,6 @@ class TestCreateEmailTemplate:
     def _api_create_email_template(
             client,
             template_type,
-            name,
             subject_line,
             message,
             expected_status_code=200,
@@ -192,7 +185,6 @@ class TestCreateEmailTemplate:
             '/api/email/template/create',
             data=json.dumps({
                 'templateType': template_type,
-                'name': name,
                 'subjectLine': subject_line,
                 'message': message,
             }),
@@ -201,12 +193,21 @@ class TestCreateEmailTemplate:
         assert response.status_code == expected_status_code
         return response.json
 
-    def api_update_capability(self, client):
+    @staticmethod
+    def _api_delete_email_template(
+            client,
+            template_id,
+            expected_status_code=200,
+    ):
+        response = client.delete(f'/api/email/template/delete/{template_id}')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_anonymous(self, client):
         """Denies anonymous access."""
         self._api_create_email_template(
             client,
             template_type='changes_confirmed',
-            name='Captain who?',
             subject_line='Captain Howdy.',
             message="Who's Captain Howdy?",
             expected_status_code=401,
@@ -217,18 +218,34 @@ class TestCreateEmailTemplate:
         self._api_create_email_template(
             client,
             template_type='changes_confirmed',
-            name='Captain who?',
             subject_line='Captain Howdy.',
             message="Who's Captain Howdy?",
             expected_status_code=401,
         )
 
-    def test_successful_create(self, client, admin_session):
+    def test_no_duplicate(self, client, admin_session):
+        """Multiple templates of same type cannot be created."""
+        existing_template = next((t for t in EmailTemplate.all_templates() if t.template_type == 'changes_confirmed'), None)
+        assert existing_template
+
+        self._api_create_email_template(
+            client,
+            template_type='changes_confirmed',
+            subject_line='Captain Howdy.',
+            message="Who's Captain Howdy?",
+            expected_status_code=400,
+        )
+
+    def test_no_duplicate_create(self, client, admin_session):
         """Admin user has success."""
+        existing_template = next((t for t in EmailTemplate.all_templates() if t.template_type == 'changes_confirmed'), None)
+        assert existing_template
+
+        self._api_delete_email_template(client, existing_template.id)
+
         email_template = self._api_create_email_template(
             client,
             template_type='changes_confirmed',
-            name='Captain who?',
             subject_line='Captain Howdy.',
             message="Who's Captain Howdy?",
         )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1090

Our more rigorously defined `template_type` enum is enough. Note migration script included.