### PR TITLE
DIABLO-1100: prevents btn spinner from changing table height

### DIFF
--- a/src/components/util/Snackbar.vue
+++ b/src/components/util/Snackbar.vue
@@ -1,36 +1,35 @@
 <template>
-  <v-snackbar
-    v-model="snackbarShow"
-    :color="snackbar.color"
-    content-class="align-center"
-    location="top"
-    :timeout="snackbar.timeout"
-  >
-    <div class="d-flex align-center justify-space-between py-1">
-      <div
-        id="alert-text"
-        aria-live="polite"
-        class="px-4"
-        role="alert"
-      >
-        <div class="pb-4 text-h6">{{ snackbar.text }}</div>
-        <ContactUsPrompt
-          v-if="includeContactUsPrompt"
-          href-mailto-class="text-white"
-        />
+  <div id="snackbar-container" aria-live="assertive" role="alert">
+    <v-snackbar
+      v-model="snackbarShow"
+      attach="#snackbar-container"
+      :color="snackbar.color"
+      content-class="align-center"
+      location="top"
+      :timeout="snackbar.timeout"
+    >
+      <div class="d-flex align-center justify-space-between py-1">
+        <div id="alert-text" class="px-4">
+          <div class="text-h6">{{ snackbar.text }}</div>
+          <ContactUsPrompt
+            v-if="includeContactUsPrompt"
+            class="mb-4"
+            href-mailto-class="text-white"
+          />
+        </div>
+        <div>
+          <v-btn
+            id="btn-close-alert"
+            aria-label="Close alert"
+            variant="text"
+            @click="contextStore.snackbarClose"
+          >
+            Close
+          </v-btn>
+        </div>
       </div>
-      <div>
-        <v-btn
-          id="btn-close-alert"
-          aria-label="Close alert"
-          variant="text"
-          @click="contextStore.snackbarClose"
-        >
-          Close
-        </v-btn>
-      </div>
-    </div>
-  </v-snackbar>
+    </v-snackbar>
+  </div>
 </template>
 
 <script setup>

--- a/src/views/Jobs.vue
+++ b/src/views/Jobs.vue
@@ -8,7 +8,7 @@
           text="The Chancel"
         />
       </v-card-title>
-      <v-card-text>
+      <v-card-text class="px-0">
         <v-data-table
           id="job-schedule-table"
           class="v-table-padding-override"
@@ -44,6 +44,7 @@
                     :id="`run-job-${job.key}`"
                     :aria-label="`Run job ${job.name}`"
                     bg-color="transparent"
+                    class="my-1"
                     :disabled="isRunning(job.key)"
                     icon
                     size="large"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1100

Also moves the aria-live region from inside the snackbar to wrap around it. Live regions should be present on the page before the content appears.