### PR TITLE
DIABLO-1148: fixes table header sort button issues for screen reader

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,23 +1,27 @@
 <template>
   <div>
-    <span
-      v-if="screenReaderAlert"
+    <div
       id="screen-reader-alert"
       class="sr-only"
-      aria-live="polite"
-      role="alert"
+      :aria-live="ariaLive"
+      :role="ariaLive === 'assertive' ? 'alert' : undefined"
     >
-      {{ screenReaderAlert }}
-    </span>
+      <span v-if="get(screenReaderAlert, 'message', '').length">
+        {{ screenReaderAlert.message }}
+      </span>
+    </div>
     <router-view />
   </div>
 </template>
 
 <script setup>
+import {computed} from 'vue'
+import {get} from 'lodash'
 import {storeToRefs} from 'pinia'
 import {useContextStore} from '@/stores/context'
 
 const {screenReaderAlert} = storeToRefs(useContextStore())
+const ariaLive = computed(() => get(screenReaderAlert, 'politeness', 'polite'))
 </script>
 
 <style>

--- a/src/components/course/CourseHistory.vue
+++ b/src/components/course/CourseHistory.vue
@@ -1,7 +1,14 @@
 <template>
-  <v-card id="update-history" class="border-sm">
+  <v-card
+    id="update-history"
+    aria-labelledby="update-history-header"
+    class="border-sm"
+    role="region"
+  >
     <v-card-title>
-      <h2>Update history</h2>
+      <h2 id="update-history-header">
+        <span class="sr-only">Course </span>Update history
+      </h2>
     </v-card-title>
     <v-card-text class="px-0">
       <v-data-table
@@ -29,8 +36,8 @@
               <template v-if="history.length >= 2">
                 <v-btn
                   :id="`update-history-sort-by-${column.value}-btn`"
-                  :append-icon="getSortIcon(column)"
-                  :aria-label="`Sort by ${column.title} ${isSorted(column) && sortBy.order === 'asc' ? 'descending' : 'ascending'}`"
+                  :append-icon="isSorted(column) ? getSortIcon(column) : undefined"
+                  :aria-label="sortButtonAriaLabel(column, isSorted)"
                   class="font-size-13 font-weight-bold height-unset min-width-unset pa-1 text-transform-unset v-table-sort-btn-override"
                   :class="{'icon-visible': sortBy[0] === column.value}"
                   density="compact"
@@ -134,8 +141,15 @@ const onUpdateSortBy = primarySortBy => {
     }
   } else {
     sortBy.value = {key: '', order: ''}
-    alertScreenReader('Unsorted')
+    alertScreenReader('Default sort order restored')
   }
 }
 
+const sortButtonAriaLabel = (column, isSorted) => {
+  if (isSorted(column) && 'desc' === sortBy.value.order) {
+    return 'Restore default sort order'
+  } else {
+    return `Sort by ${column.title} ${isSorted(column) && sortBy.value.order === 'asc' ? 'descending' : 'ascending'}`
+  }
+}
 </script>

--- a/src/components/course/CoursesDataTable.vue
+++ b/src/components/course/CoursesDataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div aria-describedby="courses-data-table-message" aria-label="Courses table" role="region">
     <v-row id="courses-data-table-message" class="text-medium-emphasis pb-1 px-4">
       <span class="ml-4">{{ messageForCourses }}</span>
       <v-spacer />
@@ -227,7 +227,7 @@
 </template>
 
 <script setup>
-import {each, filter, get, map, size, tail} from 'lodash'
+import {each, filter, find, get, map, size, tail} from 'lodash'
 import {mdiClose} from '@mdi/js'
 import {onMounted, ref, watch} from 'vue'
 import {alertScreenReader,getDisplayMeetings} from '@/lib/utils'

--- a/src/components/util/Footer.vue
+++ b/src/components/util/Footer.vue
@@ -10,10 +10,10 @@
           <ContactUsPrompt href-mailto-class="on-secondary" />
         </v-col>
         <v-col class="d-flex justify-end" cols="12" sm="6">
-          <span v-if="config.isVueAppDebugMode && screenReaderAlert">
-            {{ screenReaderAlert }}
+          <span v-if="config.isVueAppDebugMode && get(screenReaderAlert, 'message', '').length">
+            {{ screenReaderAlert.message }}
           </span>
-          <span v-if="!config.isVueAppDebugMode || !screenReaderAlert">
+          <span v-if="!config.isVueAppDebugMode || !get(screenReaderAlert, 'message', '').length">
             <v-icon :icon="mdiCopyright" size="small" />
             <span class="sr-only">Copyright</span> {{ new Date().getFullYear() }}
             The Regents of the University of California
@@ -25,6 +25,7 @@
 </template>
 
 <script setup>
+import {get} from 'lodash'
 import {mdiCopyright} from '@mdi/js'
 import {storeToRefs} from 'pinia'
 import ContactUsPrompt from '@/components/util/ContactUsPrompt'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -151,3 +151,8 @@ export interface DiabloUser {
   name: string,
   uid: string | null
 }
+
+export type ScreenReaderAlert = {
+  message: string,
+  politeness: string
+}

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -1,13 +1,16 @@
 import {defineStore} from 'pinia'
 import {get, toString} from 'lodash'
-import type {DiabloConfig, DiabloUser} from '@/lib/types'
+import type {DiabloConfig, DiabloUser, ScreenReaderAlert} from '@/lib/types'
 import {ANONYMOUS_USER, putFocusNextTick} from '@/lib/utils'
 import router from '@/router'
 
 export const useContextStore = defineStore('context', {
   state: () => ({
     loading: false,
-    screenReaderAlert: undefined as string | undefined,
+    screenReaderAlert: {
+      message: '',
+      politeness: 'polite'
+    } as ScreenReaderAlert,
     snackbar: {
       color: 'primary' as string | undefined,
       text: undefined as string | undefined,
@@ -23,23 +26,35 @@ export const useContextStore = defineStore('context', {
       const route = router.currentRoute.value
       const pageTitle: string = title || toString(get(route, 'name'))
       this.loading = true
-      this.screenReaderAlert = `Loading ${pageTitle} page.`
+      this.screenReaderAlert = {
+        message: `Loading ${pageTitle} page.`,
+        politeness: 'polite'
+      }
     },
     loadingComplete(title?: string, srAlert?: string) {
       const route = router.currentRoute.value
       const pageTitle: string = title || toString(get(route, 'name'))
       document.title = `${pageTitle ? pageTitle : 'Welcome'} | Course Capture`
       this.loading = false
-      this.screenReaderAlert = `${pageTitle || String(get(route, 'name', ''))} page loaded. ${srAlert || ''}`
+      this.screenReaderAlert = {
+        message: `${pageTitle || String(get(route, 'name', ''))} page loaded. ${srAlert || ''}`,
+        politeness: 'polite'
+      }
       putFocusNextTick('page-title')
     },
-    alertScreenReader(message: string) {
-      this.screenReaderAlert = message
+    alertScreenReader(message: string, politeness?: string) {
+      this.screenReaderAlert = {
+        message: message,
+        politeness: politeness || 'polite'
+      }
     },
     snackbarClose() {
       this.snackbarShow = false
       this.snackbar.text = undefined
-      this.screenReaderAlert = 'Message closed'
+      this.screenReaderAlert = {
+        message: 'Message closed',
+        politeness: 'polite'
+      }
     },
     snackbarOpen(text: string) {
       this.snackbar.text = text

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -37,8 +37,14 @@
       </v-container>
       <Spinner v-if="refreshingCourses" />
       <template v-if="!refreshingCourses">
-        <v-row v-for="(courses, index) in [eligibleCourses, ineligibleCourses]" :key="index" class="py-5">
-          <h2 class="pa-4 text-medium-emphasis w-100">
+        <v-row
+          v-for="(courses, index) in [eligibleCourses, ineligibleCourses]"
+          :key="index"
+          :aria-labelledby="`${getTableId(index)}-header`"
+          class="py-5"
+          role="region"
+        >
+          <h2 :id="`${getTableId(index)}-header`" class="pa-4 text-medium-emphasis w-100">
             {{ index === 0 ? 'Courses eligible for capture' : 'Courses not in a course capture classroom' }}
           </h2>
           <div class="overflow-x-auto px-md-4 w-100">

--- a/src/views/room/Rooms.vue
+++ b/src/views/room/Rooms.vue
@@ -49,8 +49,8 @@
           >
             <v-btn
               :id="`rooms-table-sort-by-${column.value}-btn`"
-              :append-icon="getSortIcon(column)"
-              :aria-label="`Sort by ${column.title} ${isSorted(column) && sortBy.order === 'asc' ? 'descending' : 'ascending'}`"
+              :append-icon="isSorted(column) ? getSortIcon(column) : undefined"
+              :aria-label="sortButtonAriaLabel(column, isSorted)"
               class="font-size-13 font-weight-bold height-unset min-width-unset pa-1 text-transform-unset v-table-sort-btn-override"
               :class="{'icon-visible': isSorted(column)}"
               density="compact"
@@ -105,7 +105,7 @@
 
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import {get, size, startsWith} from 'lodash'
+import {find, get, size, startsWith} from 'lodash'
 import {mdiDomain, mdiMagnify} from '@mdi/js'
 import {alertScreenReader} from '@/lib/utils'
 import PageTitle from '@/components/util/PageTitle'
@@ -142,14 +142,22 @@ const onUpdateSortBy = primarySortBy => {
   const key = get(primarySortBy, '0.key')
   pageCurrent.value = 1
   if (key) {
-    const header = find(headers.value, {value: key})
+    const header = find(headers, {value: key})
     sortBy.value = primarySortBy[0]
     if (header) {
       alertScreenReader(`Sorted by ${header.title}, ${sortBy.value.order}ending`)
     }
   } else {
     sortBy.value = {key: '', order: ''}
-    alertScreenReader('Unsorted')
+    alertScreenReader('Default sort order restored')
+  }
+}
+
+const sortButtonAriaLabel = (column, isSorted) => {
+  if (isSorted(column) && 'desc' === sortBy.value.order) {
+    return 'Restore default sort order'
+  } else {
+    return `Sort by ${column.title} ${isSorted(column) && sortBy.value.order === 'asc' ? 'descending' : 'ascending'}`
   }
 }
 </script>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1148

Also makes screen reader alerts "polite" by default. We don't want JAWS saying "ALERT!" before every message.