### PR TITLE
Xena: rationalize test data fixture

### DIFF
--- a/config/xena.py
+++ b/config/xena.py
@@ -56,7 +56,6 @@ RIPLEY_BASE_URL = 'https://ripley-dev.ets.berkeley.edu'
 TESTING = True
 
 TEST_DATA_COURSES = f'{BASE_DIR}/xena/fixtures/test-courses.json'
-TEST_DATA_USER_EMAIL = 'foo@bar.edu'
 TEST_DATA_USER_UID = '1234567'
 
 TIMEOUT_SHORT = 10

--- a/xena/fixtures/test-courses.json
+++ b/xena/fixtures/test-courses.json
@@ -1,100 +1,6 @@
 {
   "courses": [
     {
-      "test_script": "test_user_permissions",
-      "dept_code": "HISTORY",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "O'Brien 212"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "2:00 pm",
-            "end_time": "3:29 pm"
-          }
-        }
-      ]
-    },
-    {
-      "test_script": "test_scheduling_0",
-      "dept_code": "ECON",
-      "instructors": [
-        {
-          "role": "TNIC"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Pimentel 1"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "7:00 am",
-            "end_time": "8:29 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
-      "test_script": "test_scheduling_1",
-      "dept_code": "PSYCH",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Pimentel 1"
-          },
-          "meeting_schedule": {
-            "days": "MO, WE",
-            "start_time": "7:00 am",
-            "end_time": "7:59 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
-      "test_script": "test_scheduling_2",
-      "dept_code": "PHYSICS",
-      "instructors": [
-        {
-          "role": "PI"
-        },
-        {
-          "role": "ICNT"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "O'Brien 212"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "6:30 am",
-            "end_time": "7:59 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
       "test_script": "test_collaborators_0",
       "dept_code": "GERMAN",
       "instructors": [
@@ -181,51 +87,6 @@
           },
           "meeting_schedule": {
             "days": "TU, TH",
-            "start_time": "7:00 am",
-            "end_time": "7:59 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
-      "test_script": "test_x_listings",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "O'Brien 212"
-          },
-          "meeting_schedule": {
-            "days": "MO, WE, FR",
-            "start_time": "8:00 am",
-            "end_time": "8:59 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
-      "test_script": "test_course_cancellation",
-      "dept_code": "CHEM",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "O'Brien 212"
-          },
-          "meeting_schedule": {
-            "days": "MO, WE, FR",
             "start_time": "5:00 pm",
             "end_time": "5:59 pm"
           }
@@ -234,119 +95,7 @@
       "listings": []
     },
     {
-      "test_script": "test_course_changes_auditorium",
-      "dept_code": "ENGLISH",
-      "instructors": [
-        {
-          "role": "TNIC"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Pimentel 1"
-          },
-          "meeting_schedule": {
-            "days": "MO, WE",
-            "start_time": "6:00 am",
-            "end_time": "6:59 am"
-          }
-        }
-      ]
-    },
-    {
-      "test_script": "test_course_changes_ineligible",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [
-        {
-          "role": "APRX"
-        }
-      ],
-      "meetings": [
-        {
-          "room": {
-            "name": "Chavez 100"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "9:30 pm",
-            "end_time": "10:59 pm"
-          }
-        }
-      ]
-    },
-    {
-      "test_script": "test_course_changes_faker",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Pimentel 1"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "6:30 pm",
-            "end_time": "7:59 pm"
-          }
-        }
-      ]
-    },
-    {
-      "test_script": "test_course_changes_eligible",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Dwinelle 104"
-          },
-          "meeting_schedule": {
-            "days": "TU, TH",
-            "start_time": "8:30 pm",
-            "end_time": "9:59 pm"
-          }
-        }
-      ]
-    },
-    {
-      "test_script": "test_unschedule",
-      "dept_code": "EPS",
-      "instructors": [
-        {
-          "role": "PI"
-        }
-      ],
-      "proxies": [],
-      "meetings": [
-        {
-          "room": {
-            "name": "Pimentel 1"
-          },
-          "meeting_schedule": {
-            "days": "FR",
-            "start_time": "4:00 am",
-            "end_time": "5:59 am"
-          }
-        }
-      ],
-      "listings": []
-    },
-    {
-      "test_script": "test_weird_type_b",
+      "test_script": "test_multi_meetings_0",
       "dept_code": "LEGALST",
       "instructors": [
         {
@@ -361,8 +110,8 @@
           },
           "meeting_schedule": {
             "days": "MO, WE, FR",
-            "start_time": "5:00 am",
-            "end_time": "5:59 am"
+            "start_time": "6:00 pm",
+            "end_time": "6:59 pm"
           }
         },
         {
@@ -371,14 +120,14 @@
           },
           "meeting_schedule": {
             "days": "MO, WE, FR",
-            "start_time": "5:00 am",
-            "end_time": "5:59 am"
+            "start_time": "6:00 pm",
+            "end_time": "6:59 pm"
           }
         }
       ]
     },
     {
-      "test_script": "test_weird_type_b_changes",
+      "test_script": "test_multi_meetings_0_changes",
       "instructors": [
         {
           "role": "PI"
@@ -392,8 +141,8 @@
           },
           "meeting_schedule": {
             "days": "MO, WE, FR",
-            "start_time": "5:00 am",
-            "end_time": "5:59 am"
+            "start_time": "5:00 pm",
+            "end_time": "5:59 pm"
           }
         },
         {
@@ -402,14 +151,14 @@
           },
           "meeting_schedule": {
             "days": "MO, WE, FR",
-            "start_time": "5:00 am",
-            "end_time": "5:59 am"
+            "start_time": "5:00 pm",
+            "end_time": "5:59 pm"
           }
         }
       ]
     },
     {
-      "test_script": "test_weird_type_c",
+      "test_script": "test_multi_meetings_1",
       "dept_code": "STAT",
       "instructors": [
         {
@@ -441,7 +190,7 @@
       ]
     },
     {
-      "test_script": "test_weird_type_c_changes",
+      "test_script": "test_multi_meetings_1_changes",
       "instructors": [
         {
           "role": "PI"
@@ -472,7 +221,7 @@
       ]
     },
     {
-      "test_script": "test_weird_type_d",
+      "test_script": "test_multi_meetings_2",
       "dept_code": "COMPSCI",
       "instructors": [
         {
@@ -504,7 +253,7 @@
       ]
     },
     {
-     "test_script": "test_opt_out_0",
+      "test_script": "test_opt_out_0",
       "dept_code": "COMPSCI",
       "instructors": [
         {
@@ -539,7 +288,7 @@
       ]
     },
     {
-     "test_script": "test_opt_out_1",
+      "test_script": "test_opt_out_1",
       "dept_code": "PHYSICS",
       "instructors": [
         {
@@ -559,6 +308,234 @@
           }
         }
       ]
+    },
+    {
+      "test_script": "test_single_meeting_settings_changes_0",
+      "dept_code": "ECON",
+      "instructors": [
+        {
+          "role": "TNIC"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "Pimentel 1"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "7:00 pm",
+            "end_time": "7:59 pm"
+          }
+        }
+      ],
+      "listings": []
+    },
+    {
+      "test_script": "test_single_meeting_settings_changes_1",
+      "dept_code": "PSYCH",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "Pimentel 1"
+          },
+          "meeting_schedule": {
+            "days": "MO, WE",
+            "start_time": "7:00 pm",
+            "end_time": "7:59 pm"
+          }
+        }
+      ],
+      "listings": []
+    },
+    {
+      "test_script": "test_single_meeting_settings_changes_2",
+      "dept_code": "PHYSICS",
+      "instructors": [
+        {
+          "role": "PI"
+        },
+        {
+          "role": "ICNT"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "O'Brien 212"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "6:00 pm",
+            "end_time": "6:59 pm"
+          }
+        }
+      ],
+      "listings": []
+    },
+    {
+      "test_script": "test_single_meeting_sis_cancellation",
+      "dept_code": "CHEM",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "O'Brien 212"
+          },
+          "meeting_schedule": {
+            "days": "MO, WE, FR",
+            "start_time": "5:00 pm",
+            "end_time": "5:59 pm"
+          }
+        }
+      ],
+      "listings": []
+    },
+    {
+      "test_script": "test_single_meeting_sis_changes",
+      "dept_code": "ENGLISH",
+      "instructors": [
+        {
+          "role": "TNIC"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "Pimentel 1"
+          },
+          "meeting_schedule": {
+            "days": "MO, WE",
+            "start_time": "6:00 pm",
+            "end_time": "6:59 pm"
+          }
+        }
+      ]
+    },
+    {
+      "test_script": "test_single_meeting_sis_changes_room_eligible",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "Dwinelle 104"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "8:30 pm",
+            "end_time": "9:59 pm"
+          }
+        }
+      ]
+    },
+    {
+      "test_script": "test_single_meeting_sis_changes_room_ineligible",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [
+        {
+          "role": "APRX"
+        }
+      ],
+      "meetings": [
+        {
+          "room": {
+            "name": "Chavez 100"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "9:30 pm",
+            "end_time": "10:59 pm"
+          }
+        }
+      ]
+    },
+    {
+      "test_script": "test_single_meeting_sis_changes_schedule",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "Pimentel 1"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "6:30 pm",
+            "end_time": "7:59 pm"
+          }
+        }
+      ]
+    },
+    {
+      "test_script": "test_user_permissions",
+      "dept_code": "HISTORY",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "O'Brien 212"
+          },
+          "meeting_schedule": {
+            "days": "TU, TH",
+            "start_time": "2:00 pm",
+            "end_time": "3:29 pm"
+          }
+        }
+      ]
+    },
+    {
+      "test_script": "test_x_listings",
+      "instructors": [
+        {
+          "role": "PI"
+        }
+      ],
+      "proxies": [],
+      "meetings": [
+        {
+          "room": {
+            "name": "O'Brien 212"
+          },
+          "meeting_schedule": {
+            "days": "MO, WE, FR",
+            "start_time": "8:00 pm",
+            "end_time": "8:59 pm"
+          }
+        }
+      ],
+      "listings": []
     }
   ]
 }

--- a/xena/pages/room_printable_page.py
+++ b/xena/pages/room_printable_page.py
@@ -64,7 +64,7 @@ class RoomPrintablePage(DiabloPages):
 
     def visible_times(self, section):
         els = self.elements((By.XPATH, f'//td[@id="course-{section.ccn}-times"]/div'))
-        return [el.get_dom_attribute('innerText').strip() for el in els]
+        return [el.text.strip() for el in els]
 
     def visible_recording_type(self, section):
         return self.element((By.ID, f'course-{section.ccn}-recording-type')).text.strip()

--- a/xena/test_utils/util.py
+++ b/xena/test_utils/util.py
@@ -83,10 +83,7 @@ def get_password():
 
 
 def get_test_collaborator():
-    return User({
-        'email': app.config['TEST_DATA_USER_EMAIL'],
-        'uid': app.config['TEST_DATA_USER_UID'],
-    })
+    return User({'uid': app.config['TEST_DATA_USER_UID']})
 
 
 def get_kaltura_term_date_str(date):

--- a/xena/tests/test_multi_meetings_0.py
+++ b/xena/tests/test_multi_meetings_0.py
@@ -50,7 +50,7 @@ class TestWeirdTypeB:
     """
 
     # Initial course data
-    test_data = util.get_test_script_course('test_weird_type_b')
+    test_data = util.get_test_script_course('test_multi_meetings_0')
     section = util.get_test_section(test_data)
     meeting_physical = section.meetings[0]
     meeting_online = section.meetings[1]
@@ -60,7 +60,7 @@ class TestWeirdTypeB:
     recording_schedule = RecordingSchedule(section, meeting_physical)
 
     # Course changes data
-    test_data_changes = util.get_test_script_course('test_weird_type_b_changes')
+    test_data_changes = util.get_test_script_course('test_multi_meetings_0_changes')
     uids_to_exclude = list(map(lambda i: i.uid, section.instructors))
     util.get_test_section_instructor_data(test_data_changes, uids_to_exclude=uids_to_exclude)
     changed_section = Section(test_data_changes)

--- a/xena/tests/test_multi_meetings_1.py
+++ b/xena/tests/test_multi_meetings_1.py
@@ -49,7 +49,7 @@ class TestWeirdTypeC:
     """
 
     # Initial course data
-    test_data = util.get_test_script_course('test_weird_type_c')
+    test_data = util.get_test_script_course('test_multi_meetings_1')
     section = util.get_test_section(test_data)
     original_instructor = section.instructors[0]
 
@@ -65,7 +65,7 @@ class TestWeirdTypeC:
     meeting_1.meeting_schedule.start_date = meeting_0.meeting_schedule.end_date + timedelta(days=1)
 
     # Course changes data
-    test_data_changes = util.get_test_script_course('test_weird_type_c_changes')
+    test_data_changes = util.get_test_script_course('test_multi_meetings_1_changes')
     uids_to_exclude = list(map(lambda i: i.uid, section.instructors))
     util.get_test_section_instructor_data(test_data_changes, uids_to_exclude=uids_to_exclude)
     changed_section = Section(test_data_changes)
@@ -313,10 +313,6 @@ class TestWeirdTypeC:
         self.kaltura_page.verify_collaborators(self.section)
         self.kaltura_page.verify_schedule(self.section, self.meeting_1)
         self.kaltura_page.verify_publish_status(self.recording_sched_1)
-
-    def test_instructor_added_email(self):
-        assert util.get_sent_email_count(EmailTemplateType.INSTR_ADDED, self.section,
-                                         self.new_instructor) == 1
 
     # START / END DATES CHANGE FOR BOTH SECTIONS
 

--- a/xena/tests/test_multi_meetings_2.py
+++ b/xena/tests/test_multi_meetings_2.py
@@ -47,7 +47,7 @@ class TestWeirdTypeD:
     - Series updated
     """
 
-    test_data = util.get_test_script_course('test_weird_type_d')
+    test_data = util.get_test_script_course('test_multi_meetings_2')
     section = util.get_test_section(test_data)
     meeting_0 = section.meetings[0]
     meeting_0.meeting_schedule.end_date = meeting_0.meeting_schedule.end_date - timedelta(days=8)

--- a/xena/tests/test_single_meeting_settings_changes_0.py
+++ b/xena/tests/test_single_meeting_settings_changes_0.py
@@ -47,7 +47,7 @@ class TestScheduling0:
     - Series updated
     """
 
-    test_data = util.get_test_script_course('test_scheduling_0')
+    test_data = util.get_test_script_course('test_single_meeting_settings_changes_0')
     section = util.get_test_section(test_data)
     admin = User({'uid': util.get_admin_uid()})
     instructor = section.instructors[0]

--- a/xena/tests/test_single_meeting_settings_changes_1.py
+++ b/xena/tests/test_single_meeting_settings_changes_1.py
@@ -45,7 +45,7 @@ class TestScheduling1:
     - Series updated
     """
 
-    test_data = util.get_test_script_course('test_scheduling_1')
+    test_data = util.get_test_script_course('test_single_meeting_settings_changes_1')
     admin = User({'uid': util.get_admin_uid()})
     section = util.get_test_section(test_data)
     instructor = section.instructors[0]

--- a/xena/tests/test_single_meeting_settings_changes_2.py
+++ b/xena/tests/test_single_meeting_settings_changes_2.py
@@ -46,7 +46,7 @@ class TestScheduling2:
     - Instructor two reverts to no auto-publish
     """
 
-    test_data = util.get_test_script_course('test_scheduling_2')
+    test_data = util.get_test_script_course('test_single_meeting_settings_changes_2')
     section = util.get_test_section(test_data)
     instructor_0 = section.instructors[0]
     instructor_1 = section.instructors[1]

--- a/xena/tests/test_single_meeting_sis_cancellation.py
+++ b/xena/tests/test_single_meeting_sis_cancellation.py
@@ -49,7 +49,7 @@ class TestCourseCancellation:
 
     # INITIALIZE TESTS
 
-    test_data = util.get_test_script_course('test_course_cancellation')
+    test_data = util.get_test_script_course('test_single_meeting_sis_cancellation')
     section = util.get_test_section(test_data)
     instructor = section.instructors[0]
     meeting = section.meetings[0]
@@ -94,7 +94,7 @@ class TestCourseCancellation:
     def test_cancel_pre_sched_no_teacher_result(self):
         self.course_page.log_out()
         self.login_page.dev_auth(self.instructor.uid)
-        self.courses_page.wait_for_title_contains(f"Your {app.config['CURRENT_TERM_NAME']} Courses")
+        self.courses_page.wait_for_title_contains(f"Your {app.config['CURRENT_TERM_NAME']} Course")
         assert not self.courses_page.is_present(OuijaBoardPage.course_row_link_locator(self.section))
 
     # RECORDINGS NOT SCHEDULED FOR CANCELLED COURSE

--- a/xena/tests/test_single_meeting_sis_instructor_changes.py
+++ b/xena/tests/test_single_meeting_sis_instructor_changes.py
@@ -46,12 +46,12 @@ class TestCourseInstructorChanges:
     - Series updated - instructor replaced, no other changes
     """
 
-    new_instructor_test_data = util.get_test_script_course('test_course_changes_auditorium')
+    new_instructor_test_data = util.get_test_script_course('test_single_meeting_sis_changes')
     section = util.get_test_section(new_instructor_test_data)
     meeting = section.meetings[0]
     new_instructor = section.instructors[0]
 
-    old_instructor_test_data = util.get_test_script_course('test_course_changes_ineligible')
+    old_instructor_test_data = util.get_test_script_course('test_single_meeting_sis_changes_room_ineligible')
     util.get_test_section_instructor_data(old_instructor_test_data, uids_to_exclude=[new_instructor.uid])
     old_instructor = Section(old_instructor_test_data).instructors[0]
 

--- a/xena/tests/test_single_meeting_sis_room_changes.py
+++ b/xena/tests/test_single_meeting_sis_room_changes.py
@@ -47,13 +47,15 @@ class TestCourseRoomChanges:
     - Room removed altogether, recordings unscheduled
     """
 
-    section = util.get_test_section(util.get_test_script_course('test_course_changes_auditorium'))
+    section = util.get_test_section(util.get_test_script_course('test_single_meeting_sis_changes'))
     instr = section.instructors[0]
     meeting = section.meetings[0]
     recording_schedule = RecordingSchedule(section, meeting)
 
-    new_ineligible_room = Section(util.get_test_script_course('test_course_changes_ineligible')).meetings[0].room
-    new_eligible_room = Section(util.get_test_script_course('test_course_changes_eligible')).meetings[0].room
+    new_ineligible_room = Section(util.get_test_script_course(
+        'test_single_meeting_sis_changes_room_ineligible')).meetings[0].room
+    new_eligible_room = Section(util.get_test_script_course(
+        'test_single_meeting_sis_changes_room_eligible')).meetings[0].room
 
     def test_setup(self):
         self.login_page.load_page()

--- a/xena/tests/test_single_meeting_sis_schedule_changes.py
+++ b/xena/tests/test_single_meeting_sis_schedule_changes.py
@@ -43,15 +43,15 @@ class TestCourseScheduleChanges:
     - SIS schedule vanishes altogether, recordings unscheduled
     """
 
-    section = util.get_test_section(util.get_test_script_course('test_course_changes_auditorium'))
+    section = util.get_test_section(util.get_test_script_course('test_single_meeting_sis_changes'))
     instr = section.instructors[0]
     meeting = section.meetings[0]
     room = section.meetings[0].room
     recording_schedule = RecordingSchedule(section, meeting)
 
-    new_meeting = Section(util.get_test_script_course('test_course_changes_eligible')).meetings[0]
+    new_meeting = Section(util.get_test_script_course('test_single_meeting_sis_changes_room_eligible')).meetings[0]
     new_meeting.room = room
-    newer_meeting = Section(util.get_test_script_course('test_course_changes_faker')).meetings[0]
+    newer_meeting = Section(util.get_test_script_course('test_single_meeting_sis_changes_schedule')).meetings[0]
     newer_meeting.room = room
 
     def test_setup(self):


### PR DESCRIPTION
- updates 'test_script' values to match current test script names
- moves all recording schedules to evenings
- reorders the course data to match test script sequence