### PR TITLE
DIABLO-1171: handles special chars in iCal events export

### DIFF
--- a/diablo/lib/i_cal.py
+++ b/diablo/lib/i_cal.py
@@ -23,6 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 from datetime import datetime, timezone
+import re
 from tempfile import TemporaryFile
 from textwrap import TextWrapper
 
@@ -39,17 +40,19 @@ import zipstream
 
 
 ICS_FILE_HEADER = [
-    b'BEGIN:VCALENDAR\n',
-    b'PRODID:-//Google Inc//Google Calendar 70.9054//EN\n',
-    b'VERSION:2.0\n',
-    b'CALSCALE:GREGORIAN\n',
-    b'METHOD:PUBLISH\n',
-    b'X-WR-CALNAME:iCal Test\n',
-    b'X-WR-TIMEZONE:America/Los_Angeles\n',
+    'BEGIN:VCALENDAR\n',
+    'PRODID:-//Google Inc//Google Calendar 70.9054//EN\n',
+    'VERSION:2.0\n',
+    'CALSCALE:GREGORIAN\n',
+    'METHOD:PUBLISH\n',
+    'X-WR-CALNAME:iCal Test\n',
+    'X-WR-TIMEZONE:America/Los_Angeles\n',
 ]
-ICS_FILE_FOOTER = b'END:VCALENDAR'
+ICS_FILE_FOOTER = 'END:VCALENDAR'
 # The prefix makes these events easily searchable in Kaltura
 ICS_SUMMARY_PREFIX = 'qqq'
+KALTURA_TEXT_ENCODING = 'latin-1'
+NON_ALPHANUMERIC_PATTERN = re.compile(r'[^a-zA-Z0-9_ ]')
 
 wrapper = TextWrapper(expand_tabs=False, drop_whitespace=False, subsequent_indent=' ')
 
@@ -70,7 +73,7 @@ def get_zip_stream(period_end_date, period_start_date):
                 get_ics_file_name(room.location, period_start_date, period_end_date),
                 _ics_generator(events),
             )
-            manifest.append(bytes(f'{room.location}: {count} events\n', encoding='utf-8'))
+            manifest.append(f'{room.location}: {count} events\n')
             total_events += count
     if len(zip_stream.paths_to_write):
         zip_stream.write_iter('_manifest.txt', _manifest_generator(manifest, total_events))
@@ -104,6 +107,7 @@ def _get_scheduled_events(room, period_end_date, period_start_date, count=None):
     if not len(schedule):
         app.logger.info(f'{room.location} has nothing scheduled for the current term; will not generate .ics file')
 
+    location_alphanumeric = NON_ALPHANUMERIC_PATTERN.sub('', room.location.replace('&', 'and'))
     formatted_events = []
     count = 0
     for scheduled_course in schedule:
@@ -114,7 +118,7 @@ def _get_scheduled_events(room, period_end_date, period_start_date, count=None):
             recurrence_type=KalturaScheduleEventRecurrenceType.RECURRENCE,
             status=KalturaScheduleEventStatus.ACTIVE,
         )
-        formatted_events.extend(_events_to_ics_format(room.location, scheduled_course.section_id, course_meetings))
+        formatted_events.extend(_events_to_ics_format(location_alphanumeric, scheduled_course.section_id, course_meetings))
         count += len(course_meetings)
     if count:
         app.logger.info(
@@ -139,21 +143,21 @@ def _events_to_ics_format(location, section_id, events):
         description = f"DESCRIPTION:{event.get('description')}"
         unique_id = f'{now.timestamp()}{index}@{host}'
         ics_events.extend([
-            b'BEGIN:VEVENT\n',
-            b'CLASS:PUBLIC\n',
-            bytes(f'CREATED:{_format_date_for_ical(event_created_date)}\n', encoding='utf-8'),
-            bytes(f'{_wrap_text(description, wrapper)}\n', encoding='utf-8'),
-            bytes(f'DTSTART:{_format_date_for_ical(event_start_date)}\n', encoding='utf-8'),
-            bytes(f'DTEND:{_format_date_for_ical(event_end_date)}\n', encoding='utf-8'),
-            bytes(f'DTSTAMP:{_format_date_for_ical(now)}\n', encoding='utf-8'),
-            bytes(f'LAST-MODIFIED:{_format_date_for_ical(event_updated_date)}\n', encoding='utf-8'),
-            bytes(f'LOCATION:{location}\n', encoding='utf-8'),
-            b'SEQUENCE:0\n',
-            b'STATUS:CONFIRMED\n',
-            bytes(f'SUMMARY:{ICS_SUMMARY_PREFIX} {section_id}\n', encoding='utf-8'),
-            b'TRANSP:OPAQUE\n',
-            bytes(f'UID:{unique_id}\n', encoding='utf-8'),
-            b'END:VEVENT\n',
+            'BEGIN:VEVENT\n',
+            'CLASS:PUBLIC\n',
+            f'CREATED:{_format_date_for_ical(event_created_date)}\n',
+            f'{_wrap_text(description, wrapper)}\n',
+            f'DTSTART:{_format_date_for_ical(event_start_date)}\n',
+            f'DTEND:{_format_date_for_ical(event_end_date)}\n',
+            f'DTSTAMP:{_format_date_for_ical(now)}\n',
+            f'LAST-MODIFIED:{_format_date_for_ical(event_updated_date)}\n',
+            f'LOCATION:{location}\n',
+            'SEQUENCE:0\n',
+            'STATUS:CONFIRMED\n',
+            f'SUMMARY:{ICS_SUMMARY_PREFIX} {section_id}\n',
+            'TRANSP:OPAQUE\n',
+            f'UID:{unique_id}\n',
+            'END:VEVENT\n',
         ])
     return ics_events
 
@@ -168,16 +172,16 @@ def _format_date_for_filename(d):
 
 def _ics_generator(events):
     for line in ICS_FILE_HEADER:
-        yield line
+        yield bytes(line, encoding=KALTURA_TEXT_ENCODING)
     for line in events:
-        yield line
-    yield ICS_FILE_FOOTER
+        yield bytes(line, encoding=KALTURA_TEXT_ENCODING)
+    yield bytes(ICS_FILE_FOOTER, encoding=KALTURA_TEXT_ENCODING)
 
 
 def _manifest_generator(manifest, total_events):
-    yield bytes(f'Total: {total_events} events in {len(manifest)} rooms.\n\n', encoding='utf-8')
+    yield bytes(f'Total: {total_events} events in {len(manifest)} rooms.\n\n', encoding=KALTURA_TEXT_ENCODING)
     for line in manifest:
-        yield line
+        yield bytes(line, encoding=KALTURA_TEXT_ENCODING)
 
 
 def _to_utc(date_str):

--- a/tests/test_lib/test_i_cal.py
+++ b/tests/test_lib/test_i_cal.py
@@ -42,6 +42,8 @@ DATE_STAMP_PATTERN = re.compile(rb'DTSTAMP:\d{8}T\d{6}Z\n')
 LAST_MODIFIED_PATTERN = re.compile(rb'LAST-MODIFIED:\d{8}T\d{6}Z\n')
 UNIQUE_ID_PATTERN = re.compile(rb'UID:\d{10}\.\d{6,7}@diablo-test\n')
 
+CURRENT_YEAR = datetime.now().year
+
 
 def validate_header(ics_file):
     assert ics_file.readline() == b'BEGIN:VCALENDAR\n'
@@ -58,12 +60,17 @@ def validate_event(ics_file, section_id, location):
     assert ics_file.readline() == b'CLASS:PUBLIC\n'
     assert CREATED_DATE_PATTERN.fullmatch(ics_file.readline())
 
-    assert ics_file.readline().startswith(b'DESCRIPTION:')
     # description should wrap to 2 or 3 lines
-    assert ics_file.readline()
+    description = ics_file.readline()
+    description += ics_file.readline()
     next_line = ics_file.readline()
     if not next_line.startswith(b'DTSTART:'):
+        description += next_line
         next_line = ics_file.readline()
+    # remove newlines and extra spaces added by text wrapping
+    description = description.replace(b'\n', b'').replace(b'  ', b' ')
+    assert description.startswith(b'DESCRIPTION:')
+    assert description.decode().endswith(f'Copyright ©{CURRENT_YEAR} UC Regents; all rights reserved.')
 
     assert START_DATE_PATTERN.fullmatch(next_line)
     assert END_DATE_PATTERN.fullmatch(ics_file.readline())
@@ -124,9 +131,10 @@ class TestGetIcsFiles:
                 validate_header(ics_file)
                 location_match = filename_location_pattern.findall(filename)[0]
                 location = location_match.replace('_', ' ')
+                location_alphanumeric = location.replace("'", '')
                 for scheduled in room_schedules[location]:
                     for i in range(6):
-                        validate_event(ics_file, scheduled.section_id, location)
+                        validate_event(ics_file, scheduled.section_id, location_alphanumeric)
                 validate_footer(ics_file)
                 ics_file.close()
                 assert ics_file.closed
@@ -136,22 +144,23 @@ class TestGetIcsFiles:
 class TestGenerateIcsFile:
 
     def test_no_scheduled_events(self):
-        room = Room.find_room('Barker 101')
+        room = Room.find_room("O'Brien 212")
         with test_scheduling_workflow(app):
             assert not generate_ics_file(room, datetime(2025, 6, 1), datetime(2025, 5, 30))
 
     def test_scheduled_events(self):
         term_id = 2218
         section_id = 50000
-        room = Room.find_room('Barker 101')
+        room = Room.find_room("O'Brien 212")
         with test_scheduling_workflow(app):
             mock_scheduled(section_id, term_id, override_room_id=room.id)
 
             ics_file = generate_ics_file(room, datetime(2025, 6, 1), datetime(2025, 5, 30))
             assert ics_file
             validate_header(ics_file)
+            location_alphanumeric = room.location.replace("'", '')
             for i in range(6):
-                validate_event(ics_file, section_id, room.location)
+                validate_event(ics_file, section_id, location_alphanumeric)
             validate_footer(ics_file)
             ics_file.close()
             assert ics_file.closed


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1171

UTF-8 has too many characters for Kaltura so we downgrade to latin-1, which only has 256, but covers all the instructor names and course titles currently on record as well as the copyright symbol.