### PR TITLE
DIABLO-1171: relaxes unique ID regex for testing iCal export

### DIFF
--- a/tests/test_lib/test_i_cal.py
+++ b/tests/test_lib/test_i_cal.py
@@ -40,7 +40,7 @@ START_DATE_PATTERN = re.compile(rb'DTSTART:\d{8}T\d{6}Z\n')
 END_DATE_PATTERN = re.compile(rb'DTEND:\d{8}T\d{6}Z\n')
 DATE_STAMP_PATTERN = re.compile(rb'DTSTAMP:\d{8}T\d{6}Z\n')
 LAST_MODIFIED_PATTERN = re.compile(rb'LAST-MODIFIED:\d{8}T\d{6}Z\n')
-UNIQUE_ID_PATTERN = re.compile(rb'UID:\d{10}\.\d{6,7}@diablo-test\n')
+UNIQUE_ID_PATTERN = re.compile(rb'UID:\d+\.\d+@diablo-test\n')
 
 CURRENT_YEAR = datetime.now().year
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1171  

Fixes test failure from #1104.