### PR TITLE
DIABLO-1173: prevents scheduling of APRX-only courses

### DIFF
--- a/diablo/jobs/kaltura_job.py
+++ b/diablo/jobs/kaltura_job.py
@@ -66,25 +66,17 @@ class KalturaJob(BaseJob):
         return 'kaltura'
 
 
-def _get_subset_of_instructors(section_id, term_id, uids, include_deleted=False):
-    course = SisSection.get_course(
-        include_deleted=include_deleted,
-        section_id=section_id,
-        term_id=term_id,
-    )
-    return list(filter(lambda instructor: instructor['uid'] in uids, course['instructors']))
-
-
 def _schedule_new_courses(term_id, newly_scheduled_instructors):
     unscheduled_courses = get_eligible_unscheduled_courses(term_id)
     app.logger.info(f'Preparing to schedule recordings for {len(unscheduled_courses)} courses.')
     for course in unscheduled_courses:
         if course['hasOptedOut']:
             continue
-        if not len(course['instructors']):
+        authorized_instructors = list(filter(lambda i: i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES, course['instructors']))
+        if not len(authorized_instructors):
             continue
         schedule_recordings(course, remove_blackout_conflicts=True)
-        for instructor in list(filter(lambda i: i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES, course['instructors'])):
+        for instructor in authorized_instructors:
             newly_scheduled_instructors.add(instructor['uid'])
 
 
@@ -175,7 +167,6 @@ def _update_already_scheduled_events(term_id, newly_scheduled_instructors):  # n
                 if updated_collaborator_uids is not None or updated_instructor_uids is not None:
                     _handle_instructor_updates(
                         kaltura, course, scheduled, scheduled_model, schedule_updates, kaltura_schedule, updated_collaborator_uids,
-                        updated_instructor_uids,
                     )
 
                 if updated_recording_type:
@@ -271,8 +262,7 @@ def _update_already_scheduled_events(term_id, newly_scheduled_instructors):  # n
 
 
 def _handle_instructor_updates(
-    kaltura, course, scheduled, scheduled_model, schedule_updates, kaltura_schedule,
-    updated_collaborator_uids, updated_instructor_uids,
+    kaltura, course, scheduled, scheduled_model, schedule_updates, kaltura_schedule, updated_collaborator_uids,
 ):
     instructors = [i for i in course['instructors'] if i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES and not i['deletedAt']]
 

--- a/diablo/jobs/schedule_updates_job.py
+++ b/diablo/jobs/schedule_updates_job.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 
 from diablo.jobs.base_job import BaseJob
-from diablo.jobs.util import build_merged_collaborators_list, is_valid_meeting_schedule
+from diablo.jobs.util import build_merged_collaborators_list, get_eligible_unscheduled_courses, is_valid_meeting_schedule
 from diablo.lib.berkeley import are_scheduled_dates_obsolete, are_scheduled_times_obsolete, get_recording_end_date, get_recording_start_date
 from diablo.lib.util import safe_strftime
 from diablo.models.course_preference import CoursePreference
@@ -51,7 +51,7 @@ class ScheduleUpdatesJob(BaseJob):
 
 
 def _queue_schedule_updates(term_id):
-    for course in SisSection.get_courses_to_be_scheduled(term_id=term_id):
+    for course in get_eligible_unscheduled_courses(term_id):
         try:
             instructors = list(filter(lambda i: i['roleCode'] in AUTHORIZED_INSTRUCTOR_ROLE_CODES and not i['deletedAt'], course['instructors']))
             eligible_meetings = course.get('meetings', {}).get('eligible', [])

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -412,16 +412,6 @@ class SisSection(db.Model):
         )
 
     @classmethod
-    def get_courses_to_be_scheduled(cls, term_id):
-        section_ids_to_be_scheduled = list(cls._section_ids_to_be_scheduled(term_id))
-        return cls.get_courses(
-            term_id=term_id,
-            section_ids=section_ids_to_be_scheduled,
-            exclude_scheduled=True,
-            include_administrative_proxies=True,
-        )
-
-    @classmethod
     def get_courses_without_instructors(cls, term_id, include_full_schedules=True):
         sql = f"""
             SELECT
@@ -504,30 +494,6 @@ class SisSection(db.Model):
             WHERE
                 s.term_id = :term_id
                 AND (s.instructor_uid IS NULL OR s.instructor_role_code = ANY(:instructor_role_codes))
-                AND s.is_principal_listing IS TRUE
-            ORDER BY s.section_id
-        """
-        rows = db.session.execute(
-            text(sql),
-            {
-                'instructor_role_codes': ALL_INSTRUCTOR_ROLE_CODES,
-                'term_id': term_id,
-            },
-        )
-        return set([row['section_id'] for row in rows])
-
-    @classmethod
-    def _section_ids_to_be_scheduled(cls, term_id):
-        sql = """
-            SELECT DISTINCT s.section_id
-            FROM sis_sections s
-            LEFT JOIN scheduled d ON d.section_id = s.section_id AND d.term_id = s.term_id AND d.deleted_at IS NULL
-            JOIN instructors i ON i.uid = s.instructor_uid
-            WHERE
-                s.term_id = :term_id
-                AND s.deleted_at IS NULL
-                AND d.id is NULL
-                AND s.instructor_role_code = ANY(:instructor_role_codes)
                 AND s.is_principal_listing IS TRUE
             ORDER BY s.section_id
         """


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1173

The relevant change is line 79 in kaltura_job.py. Everything else is removing unused or redundant code.