### PR TITLE
DIABLO-1245, API endpoint needed for full opt-in transaction

### DIFF
--- a/diablo/api/course_controller.py
+++ b/diablo/api/course_controller.py
@@ -262,6 +262,66 @@ def update_opt_in():
         raise InternalServerError('Failed to update opt-in.')
 
 
+@app.route('/api/course/update', methods=['POST'])
+@login_required
+def update_course():
+    course = request.get_json()
+    section_id = course['sectionId']
+    term_id = course['termId']
+
+    def _update_opt_in(instructor):
+        instructor_uid = instructor['uid']
+        OptIn.update_opt_in(
+            instructor_uid=instructor_uid,
+            opt_in=instructor['hasOptedIn'],
+            section_id=section_id,
+            term_id=term_id,
+        )
+        ScheduleUpdate.queue(
+            field_name='opted_in',
+            field_value_new=instructor_uid,
+            field_value_old=None,
+            requested_by_name=current_user.name,
+            requested_by_uid=current_user.uid,
+            section_id=section_id,
+            term_id=term_id,
+        )
+
+    if current_user.is_admin:
+        for instructor in course['instructors']:
+            _update_opt_in(instructor)
+    else:
+        instructor = next((i for i in course['instructors'] if i['uid'] == current_user.uid), None)
+        _update_opt_in(instructor)
+    for collaborator in course['collaborators']:
+        CoursePreference.update_collaborator_uids(
+            collaborator_uids=collaborator['uid'],
+            section_id=section_id,
+            term_id=term_id,
+        )
+    CoursePreference.update_recording_type(
+        recording_type=course['recordingType'],
+        section_id=section_id,
+        term_id=term_id,
+    )
+    # Update publish_type
+    publish_type = course['publishType']
+    CoursePreference.update_publish_type(
+        canvas_site_ids=course['canvasSiteIds'],
+        section_id=section_id,
+        publish_type=publish_type,
+        term_id=term_id,
+    )
+    return tolerant_jsonify(SisSection.get_course(
+        term_id,
+        section_id,
+        include_canvas_sites=True,
+        include_deleted=True,
+        include_notes=current_user.is_admin,
+        include_update_history=True,
+    ))
+
+
 @app.route('/api/course/opt_out/update', methods=['POST'])
 @login_required
 def update_opt_out():  # noqa: C901, PLR0912

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -633,7 +633,8 @@ def _to_api_json(  # noqa: C901, PLR0912, PLR0915
             course = {
                 'allowedUnits': row['allowed_units'],
                 'collaboratorUids': preferences.get('collaboratorUids'),
-                'canvasSiteIds': canvas_site_ids,
+                'canvasSiteIds': canvas_site_ids or [],
+                'collaborators': preferences.get('collaborators') or [],
                 'courseName': row['course_name'],
                 'courseTitle': row['course_title'],
                 'crossListings': cross_listed_courses,
@@ -664,9 +665,6 @@ def _to_api_json(  # noqa: C901, PLR0912, PLR0915
                 'scheduled': scheduled,
                 'termId': row['term_id'],
             }
-
-            if include_full_schedules:
-                course['collaborators'] = preferences.get('collaborators')
 
             if include_update_history:
                 schedule_updates = ScheduleUpdate.get_update_history_for_section_ids(term_id=row['term_id'], section_ids=cross_listed_section_ids)

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -759,7 +759,7 @@ class TestUpdatePublishType:
 
         canvas_site_updates = [u for u in course['updateHistory'] if u['fieldName'] == 'canvas_site_ids']
         assert len(canvas_site_updates) == 2
-        assert canvas_site_updates[1]['fieldValueOld'] is None
+        assert canvas_site_updates[1]['fieldValueOld'] == []
         assert canvas_site_updates[1]['fieldValueNew'] == ['1234567']
         assert canvas_site_updates[1]['status'] == 'queued'
         assert canvas_site_updates[1]['requestedByUid'] == instructor_uids[0]


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1245

The impl of this new API (`/api/course/update`) is basic, for now. I want to allow other work to proceed. Authorization checks, etc. are coming soon. 