### PR TITLE
DIABLO-1293, /course page: admin-proxies are default collaborators

### DIFF
--- a/diablo/api/course_controller.py
+++ b/diablo/api/course_controller.py
@@ -51,6 +51,7 @@ def get_course(term_id, section_id):
     course = SisSection.get_course(
         term_id,
         section_id,
+        include_administrative_proxies=True,
         include_canvas_sites=True,
         include_deleted=True,
         include_notes=current_user.is_admin,

--- a/diablo/models/sis_section.py
+++ b/diablo/models/sis_section.py
@@ -645,9 +645,9 @@ def _to_api_json(  # noqa: C901, PLR0912, PLR0915
             scheduled = scheduled_by_section_id.get(section_id)
             opt_ins = opt_ins_by_section_id.get(section_id) or []
 
-            preferences = course_preferences_by_section_id.get(section_id)
-            if preferences:
-                preferences = preferences.to_api_json(include_collaborator_attributes=include_full_schedules)
+            preferences_object = course_preferences_by_section_id.get(section_id)
+            if preferences_object:
+                preferences = preferences_object.to_api_json(include_collaborator_attributes=include_full_schedules)
             elif scheduled:
                 preferences = scheduled[0]
             else:
@@ -684,6 +684,8 @@ def _to_api_json(  # noqa: C901, PLR0912, PLR0915
                 },
                 'nonstandardMeetingDates': False,
                 'optIns': [],
+                # The front-end needs to know if the course_preferences table has an entry for this course.
+                'preferences': preferences if preferences_object else None,
                 'publishType': preferences.get('publishType'),
                 'publishTypeName': preferences.get('publishTypeName'),
                 'recordingType': preferences.get('recordingType'),

--- a/src/components/course/Collaborators.vue
+++ b/src/components/course/Collaborators.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script lang="ts" setup>
-import {cloneDeep, find, get, map} from 'lodash'
+import {cloneDeep, each, find, get, map} from 'lodash'
 import {computed, onMounted, ref} from 'vue'
 import {storeToRefs} from 'pinia'
 import type {Collaborator} from '@/lib/types'
@@ -133,7 +133,19 @@ const personLookup = ref()
 const stagedCollaborator = ref<Collaborator | undefined>()
 
 onMounted(() => {
-  collaborators.value = cloneDeep(course.value.collaborators)
+  if (course.value.preferences || course.value.collaborators.length) {
+    collaborators.value = cloneDeep(course.value.collaborators)
+  } else {
+    // APRX instructors are default collaborators.
+    each(course.value.administrativeProxies, aprx => {
+      collaborators.value.push({
+        email: aprx.email,
+        firstName: '',
+        lastName: aprx.name,
+        uid: aprx.uid
+      })
+    })
+  }
 })
 
 const addCollaborator = () => {

--- a/src/components/course/CoursePageInstructors.vue
+++ b/src/components/course/CoursePageInstructors.vue
@@ -29,7 +29,7 @@
       <div
         v-for="(instructor, index) in instructorsSorted"
         :key="`instructor-${instructor.uid}`"
-        class="d-flex flex-column"
+        class="d-flex flex-column ml-2"
       >
         <div
           v-if="!currentUser.isAdmin && currentUser.uid !== instructor.uid && !course.deletedAt"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,7 +18,6 @@ export type DiabloConfig = {
 }
 
 export interface Collaborator {
-  csid: string,
   email: string,
   firstName: string,
   lastName: string,
@@ -116,6 +115,7 @@ export type CanvasSite = {
 }
 
 export interface Course extends BaseCourse {
+  administrativeProxies: CourseInstructor[],
   allowedUnits: number,
   canvasSiteIds: number[],
   collaboratorUids: string[],
@@ -136,6 +136,7 @@ export interface Course extends BaseCourse {
   nonstandardMeetingDates: boolean,
   note: string | undefined,
   optIns: OptIn[],
+  preferences: CoursePreferences | undefined,
   publishType: string,
   publishTypeName: string,
   recordingType: string,
@@ -149,6 +150,10 @@ export interface Course extends BaseCourse {
 export interface CourseInstructor extends Instructor {
   hasOptedIn: boolean,
   optedInAt: string | undefined
+}
+
+export interface CoursePreferences {
+  createdAt: string
 }
 
 export interface CourseSortable extends Course {

--- a/src/stores/course.ts
+++ b/src/stores/course.ts
@@ -1,3 +1,4 @@
+import {cloneDeep, filter} from 'lodash'
 import {defineStore} from 'pinia'
 import type {Course} from '@/lib/types'
 import {useContextStore} from '@/stores/context'
@@ -30,6 +31,10 @@ export const useCourseStore = defineStore('course', {
   },
   actions: {
     setCourse(course: Course) {
+      // We partition the list of instructors because APRX roles are not authorized to schedule.
+      const instructors = cloneDeep(course.instructors)
+      course.administrativeProxies = filter(instructors, ['roleCode', 'APRX'])
+      course.instructors = filter(instructors, instructor => instructor.roleCode !== 'APRX')
       this.course = course
       const eligible = this.course.meetings.eligible
       const meeting = eligible[0] || this.course.meetings.ineligible[0]

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -139,16 +139,19 @@ class TestGetCourse:
         assert api_json['meetings']['eligible'][0]['room']['location'] == 'Li Ka Shing 145'
         assert len(api_json['meetings']['eligible'][0]['room']['recordingTypeOptions']) == 2
 
-    def test_no_administrative_proxy_for_course_page(self, client, fake_auth):
-        """Course page screens out instructors with APRX role, but still returns a site."""
+    def test_course_with_administrative_proxy(self, client, fake_auth):
+        """Course has access to instructors with APRX role."""
         fake_auth.login(uid=admin_uid)
+        section_id = 50006
         api_json = api_get_course(
             client,
             term_id=self.term_id,
-            section_id=50006,
+            section_id=section_id,
         )
-        assert api_json['sectionId'] == 50006
-        assert api_json['instructors'] == []
+        assert api_json['sectionId'] == section_id
+        instructors = api_json['instructors']
+        assert len(instructors) == 1
+        assert instructors[0]['roleCode'] == 'APRX'
 
     def test_cross_listing(self, client, fake_auth):
         """Course has cross-listings."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1293

This fix required cautious updates to the course API feed. The front-end will only offer APRXers as default collaborators if course-preferences have never been set.