### PR TITLE
DIABLO-1329, admin opting-out fix: course is properly unscheduled

### DIFF
--- a/diablo/api/course_controller.py
+++ b/diablo/api/course_controller.py
@@ -282,7 +282,7 @@ def course_opt_in():
     )
     ScheduleUpdate.queue(
         field_name='opted_in',
-        field_value_new='admin' if opt_in else '',
+        field_value_new='admin' if opt_in else None,
         field_value_old=None if opt_in else 'admin',
         requested_by_name=current_user.name,
         requested_by_uid=current_user.uid,


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-1329

The Kaltura job wants `None` value to unschedule. Oddly, empty string was treated as a `True` condition.